### PR TITLE
Batch article list removals to improve performance

### DIFF
--- a/src/articlelistmodel.h
+++ b/src/articlelistmodel.h
@@ -96,5 +96,6 @@ private:
     void onRefreshFinished(FeedCore::Future<FeedCore::ArticleRef> *sender);
     void onMergeFinished(FeedCore::Future<FeedCore::ArticleRef> *sender);
     void onStatusChanged();
+    class RowRemoveHelper;
 };
 #endif // UNREADITEMMODEL_H

--- a/src/qml/ArticleList/AbstractArticleListPage.qml
+++ b/src/qml/ArticleList/AbstractArticleListPage.qml
@@ -57,7 +57,6 @@ Kirigami.ScrollablePage {
            }
            onRowsAboutToBeRemoved: function(parent, first, last){
                // force currentIndex to be updated before we check to see if it was removed
-               // TODO what are the performance implications of this?
                articleList.forceLayout();
                if (root.currentIndex < first || root.currentIndex > last)
                    return;


### PR DESCRIPTION
This should fix the performance issues with filtering long lists
except in degenerate cases (e.g. every second item is unread).
If filtering performance continues to be a problem we can move
the onRowsAboutToBeRemoved handler to a c++ helper object.

fixes #19