### PR TITLE
Include qreadable in flatpak bundle

### DIFF
--- a/com.rocksandpaper.syndic.yml
+++ b/com.rocksandpaper.syndic.yml
@@ -16,6 +16,15 @@ finish-args:
 - --talk-name=org.freedesktop.Notifications
 - --talk-name=org.kde.StatusNotifierWatcher
 modules:
+
+# qreadable is currently necessary for showing web content
+- name: qreadable
+  buildsystem: cmake-ninja
+  sources:
+  - type: git
+    url: 'https://invent.kde.org/ccarney/qreadable.git'
+    branch: master
+
 - name: syndic
   buildsystem: cmake-ninja
   sources:


### PR DESCRIPTION
qreadable is necessary for displaying web content. Add a section to the flatpak manifest to build it from git.

We are currently building qreadable from the tip of the main branch, but as it matures we will probably want to change that to build from a known-working commit.