### PR TITLE
Handle HTTP redirects within IconProvider

### DIFF
--- a/feedcore/networkaccessmanager.cpp
+++ b/feedcore/networkaccessmanager.cpp
@@ -162,11 +162,18 @@ NetworkAccessManager::NetworkAccessManager(QAbstractNetworkCache *cache, QObject
 
 NetworkAccessManager::~NetworkAccessManager() = default;
 
+static void setDefaultAttribute(QNetworkRequest &req, QNetworkRequest::Attribute attrName, QVariant attrVal)
+{
+    if (!req.attribute(attrName).isValid()) {
+        req.setAttribute(attrName, attrVal);
+    }
+}
+
 QNetworkReply *FeedCore::NetworkAccessManager::createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData)
 {
     QNetworkRequest newRequest(request);
     newRequest.setHeader(QNetworkRequest::UserAgentHeader, "syndic/1.0");
-    newRequest.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    setDefaultAttribute(newRequest, QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     newRequest.setTransferTimeout();
 
     // We don't want to keep connections open since we make one-shot downloads

--- a/src/iconprovider.h
+++ b/src/iconprovider.h
@@ -35,6 +35,7 @@ public:
 private:
     class IconImageResponse;
     class IconImageEntry;
+    IconImageEntry *getEntry(const QUrl &url);
 
     static IconProvider *s_instance;
     QSharedPointer<QNetworkAccessManager> m_nam;


### PR DESCRIPTION
Icon URLs that redirect to the same underlying source only get loaded once in the icon proveder.

This prevents cache corruption resulting from overlapping writes to the same entry. It also slightly reduces memory consumption by de-duplicating icon data in memory.

Fixes #68