### PR TITLE
Option to preload web content during update

### DIFF
--- a/feedcore/context.cpp
+++ b/feedcore/context.cpp
@@ -27,6 +27,7 @@ struct Context::PrivData {
     Scheduler *updateScheduler;
     QNetworkConfigurationManager ncm;
     Readability *readability{nullptr};
+    bool prefetchContent{false};
 
     PrivData(Storage *storage, Context *parent);
     void configureUpdates(Feed *feed, const QDateTime &timestamp = QDateTime::currentDateTime()) const;
@@ -332,4 +333,17 @@ void Context::registerFeeds(const QVector<Feed *> &feeds)
     }
 }
 
+bool Context::prefetchContent() const
+{
+    return d->prefetchContent;
+}
+
+void Context::setPrefetchContent(bool newPrefetchContent)
+{
+    if (d->prefetchContent == newPrefetchContent) {
+        return;
+    }
+    d->prefetchContent = newPrefetchContent;
+    emit prefetchContentChanged();
+}
 }

--- a/feedcore/context.h
+++ b/feedcore/context.h
@@ -46,6 +46,9 @@ class Context : public QObject
      * disables item expiration.  The default is 0.
      */
     Q_PROPERTY(qint64 expireAge READ expireAge WRITE setExpireAge NOTIFY expireAgeChanged)
+
+    Q_PROPERTY(bool prefetchContent READ prefetchContent WRITE setPrefetchContent NOTIFY prefetchContentChanged)
+
 public:
     /**
      *  Create a context from a storage backend.
@@ -142,11 +145,14 @@ public:
     void setDefaultUpdateInterval(qint64 defaultUpdateInterval);
     qint64 expireAge();
     void setExpireAge(qint64 expireAge);
+    bool prefetchContent() const;
+    void setPrefetchContent(bool newPrefetchContent);
 
 signals:
     void defaultUpdateEnabledChanged();
     void defaultUpdateIntervalChanged();
     void expireAgeChanged();
+    void prefetchContentChanged();
 
     /**
      * Emitted when a feed is added to the context.  This may be a newly-created

--- a/feedcore/updatablefeed.cpp
+++ b/feedcore/updatablefeed.cpp
@@ -4,11 +4,16 @@
  */
 
 #include "updatablefeed.h"
+#include "article.h"
+#include "context.h"
 #include "feeddiscovery.h"
 #include "networkaccessmanager.h"
+#include "readability/readability.h"
+#include "readability/readabilityresult.h"
 #include <QDebug>
 #include <QNetworkReply>
 #include <QPointer>
+#include <QQueue>
 #include <Syndication/Image>
 #include <Syndication/ParserCollection>
 using namespace FeedCore;
@@ -17,6 +22,7 @@ constexpr const int kMaxRedirects = 10;
 
 namespace
 {
+
 class LoadOperation : public QObject
 {
     Q_OBJECT
@@ -42,6 +48,37 @@ private:
     bool m_isDiscoveredFeed{false};
     void onReplyFinished();
 };
+
+class PreloadQueue : public QObject
+{
+    Q_OBJECT
+public:
+    explicit PreloadQueue(Readability *readability);
+
+    void setReadability(Readability *readability);
+    void addArticle(const ArticleRef &article);
+    void next();
+
+signals:
+    void finished();
+
+private:
+    QPointer<Readability> m_readability;
+    QQueue<ArticleRef> m_articles;
+
+    void onReadabilityResultFinished(const QString &content);
+    void onReadabilityResultError();
+};
+
+Context *findContext(Feed *feed)
+{
+    for (QObject *p = feed->parent(); p != nullptr; p = p->parent()) {
+        if (auto *c = qobject_cast<Context *>(p)) {
+            return c;
+        }
+    }
+    return nullptr;
+}
 }
 
 class UpdatableFeed::UpdaterImpl : public Feed::Updater
@@ -54,6 +91,7 @@ public:
 private:
     UpdatableFeed *m_updatableFeed{nullptr};
     QPointer<LoadOperation> m_operation;
+    QPointer<PreloadQueue> m_preloadQueue;
 
     void onSucceeded(const Syndication::FeedPtr &feed, const QUrl &changeUrl);
     void onFailed(const QString &errorString);
@@ -146,8 +184,22 @@ void UpdatableFeed::UpdaterImpl::onSucceeded(const Syndication::FeedPtr &feed, c
     if (changeUrl.isValid()) {
         m_updatableFeed->setUrl(changeUrl);
     }
+
+    if (m_updatableFeed->flags() & Feed::UseReadableContentFlag) {
+        if (Context *c = findContext(m_updatableFeed); c && c->prefetchContent()) {
+            m_preloadQueue = new PreloadQueue(c->getReadability());
+            QObject::connect(m_updatableFeed, &Feed::articleAdded, m_preloadQueue, &PreloadQueue::addArticle);
+        }
+    }
+
     m_updatableFeed->updateFromSource(feed);
-    finish();
+
+    if (m_preloadQueue != nullptr) {
+        QObject::connect(m_preloadQueue, &PreloadQueue::finished, this, &UpdaterImpl::finish);
+        QMetaObject::invokeMethod(m_preloadQueue, &PreloadQueue::next, Qt::QueuedConnection);
+    } else {
+        finish();
+    }
 }
 
 void UpdatableFeed::UpdaterImpl::onFailed(const QString &errorString)
@@ -206,6 +258,37 @@ void LoadOperation::onReplyFinished()
 
     default:
         emit failed(m_reply->errorString(), DeleteLater(this));
+    }
+}
+
+PreloadQueue::PreloadQueue(Readability *readability)
+    : m_readability(readability)
+{
+}
+
+void PreloadQueue::addArticle(const ArticleRef &article)
+{
+    m_articles << article;
+}
+
+void PreloadQueue::next()
+{
+    if (m_articles.isEmpty() || m_readability == nullptr) {
+        emit finished();
+        deleteLater();
+        return;
+    }
+
+    if (!m_articles.isEmpty() && m_readability != nullptr) {
+        ArticleRef article = m_articles.takeFirst();
+        ReadabilityResult *result = m_readability->fetch(article->url());
+        QObject::connect(result, &ReadabilityResult::finished, this, [this, article](const QString &text) {
+            article->cacheReadableContent(text);
+            next();
+        });
+
+        // just skip articles with readability failures
+        QObject::connect(result, &ReadabilityResult::error, this, &PreloadQueue::next);
     }
 }
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -232,6 +232,9 @@ void Application::bindContextPropertiesToSettings()
     QObject::connect(settings(), &Settings::expireItemsChanged, this, &Application::syncExpireAge);
     QObject::connect(settings(), &Settings::expireAgeChanged, this, &Application::syncExpireAge);
 
+    syncPrefetchContent();
+    QObject::connect(settings(), &Settings::prefetchContentChanged, this, &Application::syncPrefetchContent);
+
     if (d->settings.updateOnStart()) {
         QObject::connect(d->context, &FeedCore::Context::feedListPopulated, d->context, &FeedCore::Context::requestUpdate);
     }
@@ -250,4 +253,9 @@ void Application::syncDefaultUpdateInterval()
 void Application::syncExpireAge()
 {
     d->context->setExpireAge(d->settings.expireItems() ? d->settings.expireAge() : 0);
+}
+
+void Application::syncPrefetchContent()
+{
+    d->context->setPrefetchContent(d->settings.prefetchContent());
 }

--- a/src/application.h
+++ b/src/application.h
@@ -44,5 +44,6 @@ private:
     void syncAutomaticUpdates();
     void syncDefaultUpdateInterval();
     void syncExpireAge();
+    void syncPrefetchContent();
     void startNotifications();
 };

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -69,6 +69,26 @@ Kirigami.ScrollablePage {
         }
 
         RowLayout {
+            CheckBox {
+                id: prefetchContent
+                text: qsTr("Download web content for offline viewing")
+                checked: globalSettings.prefetchContent
+                Binding {
+                    target: globalSettings
+                    property: "prefetchContent"
+                    value: prefetchContent.checked
+                }
+            }
+            Button {
+                icon.name: "help-contextual"
+                flat: true
+                ToolTip.text: qsTr("Some web servers may not support this feature.")
+                ToolTip.visible: pressed || hovered
+                ToolTip.delay: pressed ? -1 : Kirigami.Units.toolTipDelay
+            }
+        }
+
+        RowLayout {
             Kirigami.FormData.label: qsTr("Delete old items:")
             CheckBox {
                 id: expireItems

--- a/src/settings.kcfg
+++ b/src/settings.kcfg
@@ -27,6 +27,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <entry name="expireAge" type="Int">
             <default>2592000</default>
         </entry>
+        <entry name="prefetchContent" type="Bool">
+            <default>false</default>
+        </entry>
     </group>
     <group name="MainWindow">
         <entry name="width" type="Int">


### PR DESCRIPTION
This downloads the linked web page for every new article during the update process, and stores the readability-processed content in the database. This only happens for feeds that have UseReadableContentFlag set. It substantially increases update times, but allows viewing web content when offline, and avoids delays when viewing web content with a slow internet connection.

Off by default because it can generate a lot of web requests (especially when loading a large feed for the first time) and that can trigger security measures on some web servers.

Fixes #97