### PR TITLE
Support autostart for syndic background service

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -243,6 +243,10 @@ void Application::bindContextPropertiesToSettings()
     if (d->settings.updateOnStart()) {
         QObject::connect(d->context, &FeedCore::Context::feedListPopulated, d->context, &FeedCore::Context::requestUpdate);
     }
+
+    QObject::connect(settings(), &Settings::runInBackgroundChanged, this, [this] {
+        PlatformHelper::configureBackgroundService(settings()->runInBackground());
+    });
 }
 
 void Application::syncAutomaticUpdates()

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -165,6 +165,12 @@ void Application::loadMainWindow()
     activateMainWindow();
 }
 
+void Application::startBackgroundNotifier()
+{
+    d->notifier = std::make_unique<NotificationController>(d->context);
+    QObject::connect(d->notifier.get(), &NotificationController::activate, this, &Application::loadMainWindow);
+}
+
 void Application::activateMainWindow()
 {
     const auto rootObjects = d->engine->rootObjects();
@@ -210,8 +216,7 @@ void Application::onLastWindowClosed()
         return;
     }
     unloadEngine();
-    d->notifier = std::make_unique<NotificationController>(d->context);
-    QObject::connect(d->notifier.get(), &NotificationController::activate, this, &Application::loadMainWindow);
+    startBackgroundNotifier();
 #endif
 }
 

--- a/src/application.h
+++ b/src/application.h
@@ -31,6 +31,7 @@ public:
     FeedCore::Context *context();
     Settings *settings();
     void loadMainWindow();
+    void startBackgroundNotifier();
 
 private:
     struct PrivData;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,8 @@
 
 #include "application.h"
 #include "cmake-config.h"
+#include <QCommandLineOption>
+#include <QCommandLineParser>
 #include <QQuickStyle>
 using namespace FeedCore;
 
@@ -21,7 +23,17 @@ int main(int argc, char *argv[])
 #endif
     }
 
-    app.loadMainWindow();
+    {
+        QCommandLineParser commandLine;
+        commandLine.addOption(QCommandLineOption("background"));
+        commandLine.process(app);
+
+        if (commandLine.isSet("background")) {
+            app.startBackgroundNotifier();
+        } else {
+            app.loadMainWindow();
+        }
+    }
 
     int result = Application::exec();
     return result;

--- a/src/platformhelper.cpp
+++ b/src/platformhelper.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "platformhelper.h"
+#include "cmake-config.h"
 #ifdef ANDROID
 
 #include <QAndroidJniObject>
@@ -19,8 +20,17 @@ void PlatformHelper::share(const QUrl &url)
     QAndroidJniObject::callStaticMethod<void>("com/rocksandpaper/syndic/NativeHelper", "sendUrl", "(Ljava/lang/String;)V", javaUrlString.object<jstring>());
 }
 
+void PlatformHelper::configureBackgroundService(bool)
+{
+    // background running not currently supported on android
+}
+
 #else
+#include <QCoreApplication>
+#include <QDBusInterface>
+#include <QDebug>
 #include <QDesktopServices>
+#include <QVariant>
 
 PlatformHelper::PlatformHelper(QObject *parent)
     : QObject(parent)
@@ -31,6 +41,20 @@ void PlatformHelper::share(const QUrl &url)
 {
     QString encodedUrl = QUrl::toPercentEncoding(url.toString());
     QDesktopServices::openUrl(QLatin1String("mailto:?body=") + encodedUrl);
+}
+
+void PlatformHelper::configureBackgroundService(bool enabled)
+{
+#ifdef KF5DBusAddons_FOUND
+    QDBusInterface backgroundPortal("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Background");
+    if (!backgroundPortal.isValid()) {
+        qDebug() << "Not configuring autostart because background portal wasn't available";
+        return;
+    }
+    QString executableName = qApp->applicationFilePath();
+    QVariantMap options{{"autostart", enabled}, {"commandline", QVariant::fromValue(QStringList{executableName, "--background"})}};
+    backgroundPortal.call("RequestBackground", "", options);
+#endif
 }
 
 #endif

--- a/src/platformhelper.h
+++ b/src/platformhelper.h
@@ -14,4 +14,5 @@ class PlatformHelper : public QObject
 public:
     explicit PlatformHelper(QObject *parent = nullptr);
     Q_INVOKABLE static void share(const QUrl &url);
+    static void configureBackgroundService(bool enabled);
 };


### PR DESCRIPTION
Support starting the background service from the command line using the `--background` flag, and request autostart from the flatpak portal interface if it's available.  Autostart requires an installed portal implementation with the Background permission enabled, and we quietly fall back to the old behavior if the portal isn't available.