### PR TITLE
Provide link to feed in article view

### DIFF
--- a/src/qml/ArticleList/AbstractArticleListPage.qml
+++ b/src/qml/ArticleList/AbstractArticleListPage.qml
@@ -160,7 +160,8 @@ Kirigami.ScrollablePage {
             }
             if (articleList.currentItem) {
                 const data = articleList.currentItem.data
-                root.pageRow.push("qrc:/qml/ArticlePage.qml", {item: data, nextItem: nextItem, previousItem: previousItem})
+                const showExpandedByline = (data.article.feed !== root.feed)
+                root.pageRow.push("qrc:/qml/ArticlePage.qml", {item: data, nextItem: nextItem, previousItem: previousItem, showExpandedByline: showExpandedByline})
                 data.article.isRead = true
             } else if (model && automaticOpen) {
                 pushPlaceholder();

--- a/src/qml/ArticlePage.qml
+++ b/src/qml/ArticlePage.qml
@@ -13,6 +13,7 @@ Kirigami.Page {
     id: root
     property alias item: articleView.item
     property alias isReadable: readableAction.checked
+    property alias showExpandedByline: articleView.showExpandedByline
     property var nextItem: function() {}
     property var previousItem: function() {}
     signal suspendAnimations;

--- a/src/qml/ArticleView.qml
+++ b/src/qml/ArticleView.qml
@@ -6,6 +6,7 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
+import QtQuick.Window 2.15
 import org.kde.kirigami 2.7 as Kirigami
 import com.rocksandpaper.syndic 1.0
 
@@ -14,6 +15,7 @@ ColumnLayout {
     property var item
     property string text: ""
     property string hoveredLink
+    property bool showExpandedByline: false
 
     readonly property string textStyle: "<style>
     * {
@@ -47,8 +49,9 @@ ColumnLayout {
 
     RowLayout {
         Label {
+            property string expandedByline: item.article.author + ", <a href=\"syndic-feed-link:\">" + item.article.feed.name + "</a>"
             Layout.fillWidth: true
-            text: item.article.author + ", " + item.article.feed.name
+            text: showExpandedByline ? expandedByline : item.article.author
             elide: Text.ElideRight
             horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignVCenter
@@ -57,6 +60,13 @@ ColumnLayout {
             font {
                 italic: true
                 weight: Font.Light
+            }
+
+            onLinkActivated: (link)=>{
+                const w = Window.window;
+                if (w && w.selectFeed) {
+                    w.selectFeed(item.article.feed);
+                }
             }
         }
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -168,7 +168,7 @@ Kirigami.ApplicationWindow {
         }
 
         function onNewFeedCreated(feed) {
-            feedList.selectFeed(feed)
+            selectFeed(feed)
         }
     }
 
@@ -235,5 +235,9 @@ Kirigami.ApplicationWindow {
         feedList.currentIndex = -1
         feedList.currentlySelectedFeed = null
         pushRoot(pageUrl, pageProps)
+    }
+
+    function selectFeed(feed) {
+        feedList.selectFeed(feed);
     }
 }


### PR DESCRIPTION
When an article is opened from a feed that isn't it's source feed (e.g. "All Items"), provide a link that navigates to the source feed.