### PR TITLE
Don't force clear QNetworkAccessManager connection cache

### DIFF
--- a/feedcore/networkaccessmanager.cpp
+++ b/feedcore/networkaccessmanager.cpp
@@ -192,9 +192,6 @@ void NetworkAccessManager::onFinished()
 {
     d->connectionCount--;
     d->startWaiting();
-    if (d->connectionCount == 0) {
-        clearConnectionCache();
-    }
 }
 
 void NetworkAccessManager::PrivData::startWaiting()


### PR DESCRIPTION
We had been clearing the connection cache when the number of active connections drops to 0, in order to avoid too many keep-alive connections when we have a very large number of feeds from different servers (#40).

Unfortunately, clearConnectionCache() can block the calling thread for up to 5 seconds while it waits for the QNAM's worker thread to finish, which causes sporadic UI freezes. I've removed the call to that function entirely, and the problem with accumulating open connections no longer seems to happen, even with a very large (~500 feeds) collection.