### PR TITLE
Option to set font family for article text

### DIFF
--- a/src/qml/ArticleView.qml
+++ b/src/qml/ArticleView.qml
@@ -149,7 +149,7 @@ ColumnLayout {
             textFormat: Text.RichText
             text: textStyle + modelBlock.text
             font.pointSize: Math.max(fontMetrics.font.pointSize + globalSettings.textAdjust, 6)
-            font.family: "serif"
+            font.family: globalSettings.bodyFont || "serif"
             horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignTop
             wrapMode: Text.Wrap

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -126,6 +126,18 @@ Kirigami.ScrollablePage {
             }
         }
 
+        ElasticComboBox {
+            id: articleFont
+            Kirigami.FormData.label: qsTr("Article font:")
+            model: ["", ...Qt.fontFamilies()]
+            onEditTextChanged: {
+                globalSettings.bodyFont = editText
+            }
+            Component.onCompleted: {
+                currentIndex = indexOfValue(globalSettings.bodyFont);
+            }
+        }
+
         RowLayout {
             Kirigami.FormData.label: qsTr("OPML Data:")
 

--- a/src/settings.kcfg
+++ b/src/settings.kcfg
@@ -54,5 +54,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
             </choices>
             <default>UnreadCount</default>
         </entry>
+        <entry name="bodyFont" type="String">
+            <default></default>
+        </entry>
     </group>
 </kcfg>


### PR DESCRIPTION
The default is "serif", but the default serif font is not easily user configurable, so we provide a setting to configure it manually.