### PR TITLE
Show image placeholders an animate image loading

### DIFF
--- a/src/contentimageitem.h
+++ b/src/contentimageitem.h
@@ -23,15 +23,25 @@ class ContentImageItem : public QQuickItem
      * The url to load the image from
      */
     Q_PROPERTY(QUrl source READ source WRITE setSource NOTIFY sourceChanged)
+
+    /**
+     * Whether the image has loaded sucessfully
+     */
+    Q_PROPERTY(ContentImageItem::LoadStatus loadStatus READ loadStatus NOTIFY loadStatusChanged)
 public:
+    enum LoadStatus { Loading, Complete, Cancelled, Error };
+    Q_ENUM(LoadStatus);
+
     explicit ContentImageItem(QQuickItem *parent = nullptr);
     ~ContentImageItem();
     QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *data) override;
     QUrl source() const;
     void setSource(const QUrl &src);
+    LoadStatus loadStatus();
 
 signals:
     void sourceChanged(QUrl src);
+    void loadStatusChanged();
 
 protected:
     void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) override;
@@ -42,8 +52,10 @@ private:
     QImage m_image;
     bool m_needsUpdate{false};
     QNetworkReply *m_reply{nullptr};
+    LoadStatus m_loadStatus{Loading};
 
     void beginImageLoad();
     void cancelImageLoad();
     void onImageLoadFinished();
+    void setLoadStatus(LoadStatus v);
 };


### PR DESCRIPTION
This avoids the situation where an article loads, you begin reading it, and then a slow-loading image triggers an abrupt relayout. We now show a placeholder where images are meant to be.  If the loading takes longer than a threshold time (currently hardcoded at 250ms) we show a transition to the final image when it loads.