### PR TITLE
Show all articles from category when clicking a category header

### DIFF
--- a/feedcore/CMakeLists.txt
+++ b/feedcore/CMakeLists.txt
@@ -9,7 +9,9 @@ set(feedcore_HEADERS
     future.h
     context.h
     scheduler.h
+    aggregatefeed.h
     allitemsfeed.h
+    categoryfeed.h
     factory.h
     provisionalfeed.h
     networkaccessmanager.h
@@ -30,7 +32,9 @@ set(feedcore_SRCS
     article.cpp
     context.cpp
     scheduler.cpp
+    aggregatefeed.cpp
     allitemsfeed.cpp
+    categoryfeed.cpp
     provisionalfeed.cpp
     networkaccessmanager.cpp
     starreditemsfeed.cpp

--- a/feedcore/aggregatefeed.cpp
+++ b/feedcore/aggregatefeed.cpp
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: 2021 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "aggregatefeed.h"
+#include "article.h"
+using namespace FeedCore;
+
+class AggregateFeed::Updater : public Feed::Updater
+{
+public:
+    Updater(AggregateFeed *feed, QObject *parent)
+        : Feed::Updater(feed, parent)
+    {
+    }
+
+    void run() final
+    {
+        if (auto *af = qobject_cast<AggregateFeed *>(feed())) {
+            // TODO need to pass the pending update timestamp
+            for (auto *subfeed : std::as_const(af->m_feeds)) {
+                subfeed->updater()->start();
+            }
+            finish();
+        }
+    }
+
+    void abort() final
+    {
+        if (auto *af = qobject_cast<AggregateFeed *>(feed())) {
+            for (auto *subfeed : std::as_const(af->m_active)) {
+                subfeed->updater()->abort();
+            }
+        }
+    }
+};
+
+AggregateFeed::AggregateFeed(QObject *parent)
+    : Feed(parent)
+    , m_updater{new AggregateFeed::Updater(this, this)}
+{
+}
+
+Feed::Updater *AggregateFeed::updater()
+{
+    return m_updater;
+}
+
+FeedCore::Future<ArticleRef> *AggregateFeed::getArticles(bool unreadOnly)
+{
+    return UnionFuture<ArticleRef>::create([this, unreadOnly](auto *op) {
+        for (auto *f : std::as_const(m_feeds)) {
+            op->addFuture(f->getArticles(unreadOnly));
+        }
+    });
+}
+
+void AggregateFeed::addFeed(Feed *feed)
+{
+    incrementUnreadCount(feed->unreadCount());
+    syncFeedStatus(feed);
+    QObject::connect(feed, &Feed::articleAdded, this, &AggregateFeed::onArticleAdded);
+    QObject::connect(feed, &Feed::unreadCountChanged, this, &AggregateFeed::incrementUnreadCount);
+    QObject::connect(feed, &Feed::statusChanged, this, [this, feed] {
+        syncFeedStatus(feed);
+    });
+    QObject::connect(feed, &Feed::destroyed, this, [this, feed] {
+        removeFeed(feed);
+    });
+    m_feeds << feed;
+    emit reset();
+}
+
+void AggregateFeed::removeFeed(Feed *feed)
+{
+    setFeedActive(feed, false);
+    m_feeds.remove(feed);
+}
+
+void AggregateFeed::onArticleAdded(const ArticleRef &article)
+{
+    emit articleAdded(article);
+}
+
+void AggregateFeed::setFeedActive(Feed *feed, bool active)
+{
+    if (active) {
+        m_active.insert(feed);
+    } else {
+        m_active.remove(feed);
+    }
+    setStatus(m_active.isEmpty() ? LoadStatus::Idle : LoadStatus::Updating);
+}
+
+void AggregateFeed::syncFeedStatus(Feed *sender)
+{
+    setFeedActive(sender, sender->status() == LoadStatus::Updating);
+}

--- a/feedcore/aggregatefeed.h
+++ b/feedcore/aggregatefeed.h
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: 2021 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+#include "feed.h"
+#include <QSet>
+
+namespace FeedCore
+{
+/**
+ * A Feed implementation that combines all articles from multiple feeds.
+ */
+class AggregateFeed : public FeedCore::Feed
+{
+    Q_OBJECT
+public:
+    explicit AggregateFeed(QObject *parent = nullptr);
+    FeedCore::Feed::Updater *updater() override;
+    FeedCore::Future<FeedCore::ArticleRef> *getArticles(bool unreadOnly) override;
+
+protected:
+    void addFeed(Feed *feed);
+    void removeFeed(Feed *feed);
+
+private:
+    class Updater;
+    QSet<Feed *> m_feeds;
+    QSet<Feed *> m_active;
+    Updater *m_updater{nullptr};
+    void onUnreadCountChanged(int delta);
+    void onArticleAdded(const ArticleRef &article);
+    void setFeedActive(FeedCore::Feed *feed, bool active);
+    void syncFeedStatus(FeedCore::Feed *sender);
+};
+}

--- a/feedcore/allitemsfeed.cpp
+++ b/feedcore/allitemsfeed.cpp
@@ -4,41 +4,12 @@
  */
 
 #include "allitemsfeed.h"
-#include "article.h"
 #include "context.h"
 using namespace FeedCore;
 
-namespace
-{
-class AllUpdater : public Feed::Updater
-{
-public:
-    AllUpdater(AllItemsFeed *feed, Context *context, QObject *parent)
-        : Feed::Updater(feed, parent)
-        , m_context{context}
-    {
-    }
-
-    void run() final
-    {
-        m_context->requestUpdate();
-        finish();
-    }
-
-    void abort() final
-    {
-        m_context->abortUpdates();
-    }
-
-private:
-    Context *m_context;
-};
-}
-
 AllItemsFeed::AllItemsFeed(Context *context, const QString &name, QObject *parent)
-    : Feed(parent)
+    : AggregateFeed(parent)
     , m_context{context}
-    , m_updater{new AllUpdater(this, context, this)}
 {
     setName(name);
     for (const auto &feed : context->getFeeds()) {
@@ -50,49 +21,4 @@ AllItemsFeed::AllItemsFeed(Context *context, const QString &name, QObject *paren
 Future<ArticleRef> *AllItemsFeed::getArticles(bool unreadFilter)
 {
     return m_context->getArticles(unreadFilter);
-}
-
-Feed::Updater *AllItemsFeed::updater()
-{
-    return m_updater;
-}
-
-void AllItemsFeed::addFeed(Feed *feed)
-{
-    incrementUnreadCount(feed->unreadCount());
-    syncFeedStatus(feed);
-    QObject::connect(feed, &Feed::articleAdded, this, &AllItemsFeed::onArticleAdded);
-    QObject::connect(feed, &Feed::unreadCountChanged, this, &AllItemsFeed::incrementUnreadCount);
-    QObject::connect(feed, &Feed::statusChanged, this, [this, feed] {
-        syncFeedStatus(feed);
-    });
-    QObject::connect(feed, &Feed::destroyed, this, [this, feed] {
-        onFeedDestroyed(feed);
-    });
-    emit reset();
-}
-
-void AllItemsFeed::onArticleAdded(const ArticleRef &article)
-{
-    emit articleAdded(article);
-}
-
-void AllItemsFeed::setFeedActive(Feed *feed, bool active)
-{
-    if (active) {
-        m_active.insert(feed);
-    } else {
-        m_active.remove(feed);
-    }
-    setStatus(m_active.isEmpty() ? LoadStatus::Idle : LoadStatus::Updating);
-}
-
-void AllItemsFeed::syncFeedStatus(Feed *sender)
-{
-    setFeedActive(sender, sender->status() == LoadStatus::Updating);
-}
-
-void AllItemsFeed::onFeedDestroyed(Feed *sender)
-{
-    setFeedActive(sender, false);
 }

--- a/feedcore/allitemsfeed.h
+++ b/feedcore/allitemsfeed.h
@@ -4,7 +4,7 @@
  */
 
 #pragma once
-#include "feed.h"
+#include "aggregatefeed.h"
 #include <QSet>
 
 namespace FeedCore
@@ -14,23 +14,14 @@ class Context;
 /**
  * A Feed implementation that combines all articles from a context.
  */
-class AllItemsFeed : public Feed
+class AllItemsFeed : public AggregateFeed
 {
     Q_OBJECT
 public:
     AllItemsFeed(Context *context, const QString &name, QObject *parent = nullptr);
     Future<ArticleRef> *getArticles(bool unreadFilter) final;
-    Updater *updater() final;
 
 private:
     Context *m_context{nullptr};
-    Updater *m_updater{nullptr};
-    QSet<Feed *> m_active;
-    void addFeed(Feed *feed);
-    void onUnreadCountChanged(int delta);
-    void onArticleAdded(const ArticleRef &article);
-    void setFeedActive(FeedCore::Feed *feed, bool active);
-    void syncFeedStatus(FeedCore::Feed *sender);
-    void onFeedDestroyed(FeedCore::Feed *sender);
 };
 }

--- a/feedcore/categoryfeed.cpp
+++ b/feedcore/categoryfeed.cpp
@@ -1,0 +1,17 @@
+#include "categoryfeed.h"
+#include "context.h"
+
+namespace FeedCore
+{
+
+CategoryFeed::CategoryFeed(FeedCore::Context *ctx, const QString &category, QObject *parent)
+    : AggregateFeed(parent)
+{
+    setName(category);
+    const QSet<Feed *> categories = ctx->getCategoryFeeds(category);
+    for (auto *f : categories) {
+        addFeed(f);
+    }
+}
+
+} // namespace FeedCore

--- a/feedcore/categoryfeed.h
+++ b/feedcore/categoryfeed.h
@@ -1,0 +1,18 @@
+#ifndef FEEDCORE_CATEGORYFEED_H
+#define FEEDCORE_CATEGORYFEED_H
+
+#include "aggregatefeed.h"
+
+namespace FeedCore
+{
+class Context;
+
+class CategoryFeed : public FeedCore::AggregateFeed
+{
+public:
+    CategoryFeed(FeedCore::Context *ctx, const QString &category, QObject *parent = nullptr);
+};
+
+} // namespace FeedCore
+
+#endif // FEEDCORE_CATEGORYFEED_H

--- a/feedcore/context.cpp
+++ b/feedcore/context.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 #include "context.h"
+#include "categoryfeed.h"
 #include "feed.h"
 #include "future.h"
 #include "opmlreader.h"
@@ -87,6 +88,22 @@ void Context::PrivData::configureExpiration(Feed *feed) const
 const QSet<Feed *> &Context::getFeeds()
 {
     return d->feeds;
+}
+
+QSet<Feed *> Context::getCategoryFeeds(const QString &category)
+{
+    QSet<Feed *> result;
+    for (auto *f : std::as_const(d->feeds)) {
+        if (f->category() == category) {
+            result << f;
+        }
+    }
+    return result;
+}
+
+Feed *Context::createCategoryFeed(const QString &category)
+{
+    return new CategoryFeed(this, category);
 }
 
 void Context::addFeed(ProvisionalFeed *feed)

--- a/feedcore/context.h
+++ b/feedcore/context.h
@@ -72,6 +72,23 @@ public:
     const QSet<Feed *> &getFeeds();
 
     /**
+     * Request a filtered set of feeds matching the given category.
+     *
+     * The resulting set is generated on each call, so the caller should
+     * cache it when possible.
+     */
+    QSet<Feed *> getCategoryFeeds(const QString &category);
+
+    /**
+     * Create a new category feed.
+     *
+     * The caller assumes ownership of the returned object. This function
+     * is primarily meant to be called from QML. From C++, it's preferable
+     * to create a FeedCore::CategoryFeed directly.
+     */
+    Q_INVOKABLE FeedCore::Feed *createCategoryFeed(const QString &category);
+
+    /**
      * Create a new feed in the Context's storage object.
      *
      * The feed supplied to this function will usually be a ProvisionalFeed.  The created

--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -94,6 +94,10 @@ ScrollView {
             label: section
             topPadding: padding * 2
             bottomPadding: padding * 2
+            onClicked: {
+                currentIndex = -1
+                root.currentlySelectedFeed = feedContext.createCategoryFeed(section);
+            }
         }
 
         move: Transition {


### PR DESCRIPTION
Creates a new CategoryFeed class which aggregates only the feeds that
belong to a particular category.  When the category header is clicked
a CategoryFeed is created on-the-fly and displayed.