### PR TITLE
[Android] Update colors for dark-mode toggle

### DIFF
--- a/android/src/com/rocksandpaper/syndic/SyndicActivity.java
+++ b/android/src/com/rocksandpaper/syndic/SyndicActivity.java
@@ -5,12 +5,20 @@
 
 package com.rocksandpaper.syndic;
 
+import android.content.res.Configuration;
 import org.qtproject.qt5.android.bindings.QtActivity;
 
 public class SyndicActivity extends QtActivity {
+  public native void refreshStyle();
 
   public SyndicActivity() {
     // use the theme from the manifest...
     super.QT_ANDROID_DEFAULT_THEME = null;
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    refreshStyle();
   }
 }

--- a/androidstyleplugin/androidstyleplugintheme.cpp
+++ b/androidstyleplugin/androidstyleplugintheme.cpp
@@ -6,6 +6,7 @@
 
 #include "androidstyleplugintheme.h"
 #include "androidstylepluginiconloader.h"
+#include <QAndroidJniEnvironment>
 #include <QAndroidJniObject>
 #include <QCache>
 #include <QGuiApplication>
@@ -37,6 +38,7 @@ struct StyleData {
     QObject *materialHelper{nullptr};
 
     static StyleData *createIfNecessary(QQmlEngine *engine = nullptr);
+    void loadStyle();
 
 private:
     StyleData(QQmlEngine *engine);
@@ -53,11 +55,32 @@ constexpr const float kUnscaledDefaultFontSize = 16;
 constexpr const float kUnscaledSmallFontSize = 14;
 }
 
+extern "C" {
+// TODO remove this once we can handle activity recreation
+void syndic_android_refreshStyle(JNIEnv *, jobject)
+{
+    AndroidStylePluginTheme::refreshInstances();
+}
+}
+
 StyleData::StyleData(QQmlEngine *engine)
 {
     QQmlComponent materialHelperComponent(engine, QUrl("qrc:/qml/materialhelper.qml"));
     materialHelper = materialHelperComponent.create();
+    loadStyle();
 
+    QStringList themePaths = QIcon::themeSearchPaths();
+    themePaths.append("assets:/share/icons");
+    QIcon::setThemeSearchPaths(themePaths);
+
+    QAndroidJniEnvironment env;
+    JNINativeMethod nativeMethod = {"refreshStyle", "()V", (void*)syndic_android_refreshStyle};
+    jclass c = env->FindClass("com/rocksandpaper/syndic/SyndicActivity");
+    env->RegisterNatives(c, &nativeMethod, 1);
+}
+
+void StyleData::loadStyle()
+{
     accentColor = QAndroidJniObject::callStaticMethod<jint>("com/rocksandpaper/syndic/NativeHelper", "getColor", "(I)I", COLOR_ACCENT);
     QRgb floatingBackgroundColor =
         QAndroidJniObject::callStaticMethod<jint>("com/rocksandpaper/syndic/NativeHelper", "getColor", "(I)I", COLOR_BACKGROUND_FLOATING);
@@ -90,10 +113,6 @@ StyleData::StyleData(QQmlEngine *engine)
     qApp->setFont(font);
     font.setPointSizeF(kUnscaledSmallFontSize * fontScale);
     smallFont = font;
-
-    QStringList themePaths = QIcon::themeSearchPaths();
-    themePaths.append("assets:/share/icons");
-    QIcon::setThemeSearchPaths(themePaths);
 }
 
 StyleData *StyleData::createIfNecessary(QQmlEngine *engine)
@@ -102,15 +121,21 @@ StyleData *StyleData::createIfNecessary(QQmlEngine *engine)
     return styleData;
 }
 
+static QSet<AndroidStylePluginTheme *> themeInstances;
+
 AndroidStylePluginTheme::AndroidStylePluginTheme(QObject *parent)
     : Kirigami::PlatformTheme(parent)
 {
     Q_INIT_RESOURCE(androidstyleplugin);
+    themeInstances.insert(this);
     StyleData::createIfNecessary(qmlEngine(parent));
-    updateColors();
-    setSmallFont(styleData()->smallFont);
-    setDefaultFont(qGuiApp->font());
+    refresh();
     setSupportsIconColoring(true);
+}
+
+AndroidStylePluginTheme::~AndroidStylePluginTheme()
+{
+    themeInstances.remove(this);
 }
 
 QIcon AndroidStylePluginTheme::iconFromTheme(const QString &name, const QColor &customColor)
@@ -119,6 +144,14 @@ QIcon AndroidStylePluginTheme::iconFromTheme(const QString &name, const QColor &
         return styleData()->iconLoader.getIcon({name, textColor().rgba(), highlightedTextColor().rgba()});
     }
     return styleData()->iconLoader.getIcon({name, customColor.rgba(), customColor.rgba()});
+}
+
+void AndroidStylePluginTheme::refreshInstances()
+{
+    styleData()->loadStyle();
+    for(auto *instance : std::as_const(themeInstances)) {
+        instance->refresh();
+    }
 }
 
 bool AndroidStylePluginTheme::event(QEvent *event)
@@ -130,6 +163,13 @@ bool AndroidStylePluginTheme::event(QEvent *event)
         updateColors();
     }
     return PlatformTheme::event(event);
+}
+
+void AndroidStylePluginTheme::refresh()
+{
+    updateColors();
+    setSmallFont(styleData()->smallFont);
+    setDefaultFont(qGuiApp->font());
 }
 
 void AndroidStylePluginTheme::updateColors()

--- a/androidstyleplugin/androidstyleplugintheme.h
+++ b/androidstyleplugin/androidstyleplugintheme.h
@@ -5,7 +5,6 @@
 */
 
 #pragma once
-
 #include <Kirigami2/PlatformTheme>
 
 class AndroidStylePluginTheme : public Kirigami::PlatformTheme
@@ -14,11 +13,14 @@ class AndroidStylePluginTheme : public Kirigami::PlatformTheme
 
 public:
     explicit AndroidStylePluginTheme(QObject *parent = nullptr);
+    ~AndroidStylePluginTheme();
     QIcon iconFromTheme(const QString &name, const QColor &customColor = Qt::transparent) override;
+    static void refreshInstances();
 
 protected:
     bool event(QEvent *event) override;
 
 private:
+    void refresh();
     void updateColors();
 };


### PR DESCRIPTION
This is a short-term fix for Syndic not updating when the system dark mode changes. Eventually we'll need to handle the activity being destroyed and recreated, at which point we can back this out and just let the system recreate us when uiMode changes.