### PR TITLE
Drawer actions scroll with the feed list instead of always being visible

### DIFF
--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -9,127 +9,104 @@ import QtQuick.Layouts 1.12
 import org.kde.kirigami 2.14 as Kirigami
 import com.rocksandpaper.syndic 1.0
 
-ScrollView {
-
+ListView {
     id: root
     property Feed currentlySelectedFeed
-    property alias currentIndex: feedList.currentIndex
     signal itemClicked
 
-    ScrollBar.vertical.policy: ScrollBar.AsNeeded
-    ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+    currentIndex: 0
+    clip: true
+    pressDelay: Kirigami.Settings.hasTransientTouchInput ? 120 : 0
+    highlightMoveDuration: Kirigami.Units.longDuration
 
-    ListView {
-        id: feedList
+    model: FeedListModel{
+        id: feedListModel
+        context: feedContext
+        sortMode: globalSettings.feedListSort
 
-        anchors {
-            fill: parent
-            rightMargin: root.ScrollBar.vertical.visible && !Kirigami.Settings.hasTransientTouchInput ? root.ScrollBar.vertical.width : 0
-        }
-
-        currentIndex: 0
-        clip: true
-        pressDelay: Kirigami.Settings.hasTransientTouchInput ? 120 : 0
-        highlightMoveDuration: Kirigami.Units.longDuration
-
-        model: FeedListModel{
-            id: feedListModel
-            context: feedContext
-            sortMode: globalSettings.feedListSort
-
-            onRowsRemoved: {
-                Qt.callLater(()=>{
-                    feedList.currentIndex = 0;
-                });
-            }
-        }
-
-        delegate: Kirigami.BasicListItem {
-            id: listItem
-            property var feed: model.feed
-            property var iconName: feed ? feed.icon.toString() : ""
-            property var status: feed ? feed.status : Feed.Idle
-            property var unreadCount: feed ? feed.unreadCount : 0
-            icon: iconName.length ? "image://feedicons/"+iconName : "feed-subscribe"
-            label: feed ? feed.name : ""
-            separatorVisible: false
-            padding: Kirigami.Units.largeSpacing
-            leftPadding: Kirigami.Units.smallSpacing
-            rightPadding: Kirigami.Units.smallSpacing
-            trailing: RowLayout {
-                Kirigami.Icon {
-                    source: "content-loading-symbolic-nomask"
-                    Layout.preferredHeight: contentItem.height
-                    visible: listItem.status === Feed.Updating
-                    selected: listItem.highlighted
-                }
-
-                Kirigami.Icon {
-                    source: "dialog-error-symbolic-nomask"
-                    Layout.preferredHeight: contentItem.height
-                    visible: listItem.status === Feed.Error
-                    selected: listItem.highlighted
-                }
-
-                Label {
-                    id: unreadCountLabel
-                    visible: listItem.unreadCount !== 0
-                    horizontalAlignment: Text.AlignCenter
-                    Layout.rightMargin: background.radius
-                    text: listItem.unreadCount
-                    leftInset: -background.radius
-                    rightInset: -background.radius
-                    background: Rectangle {
-                        radius: parent.height / 2.0
-                        color: Kirigami.Theme.activeBackgroundColor;
-                    }
-                }
-            }
-
-            onClicked: root.itemClicked()
-        }/* delegate */
-
-        section.property: "category"
-        section.delegate: Kirigami.ListSectionHeader {
-            label: section
-            topPadding: padding * 2
-            bottomPadding: padding * 2
-            onClicked: {
-                currentIndex = -1
-                root.currentlySelectedFeed = feedContext.createCategoryFeed(section);
-                root.itemClicked();
-            }
-        }
-
-        move: Transition {
-            enabled: root.visible
-            NumberAnimation { properties: "x, y"; duration: Kirigami.Units.shortDuration }
-        }
-
-        displaced: Transition {
-            enabled: root.visible
-            NumberAnimation { properties: "x, y"; duration: Kirigami.Units.shortDuration }
-        }
-
-        onCurrentItemChanged: {
-            if (currentItem)
-                root.currentlySelectedFeed = currentItem.feed;
+        onRowsRemoved: {
+            Qt.callLater(()=>{
+                root.currentIndex = 0;
+            });
         }
     }
 
-    Component.onCompleted: {
-        // nested scroll views cause problems so disable them
-        // TODO port away from Kirigami.GlobalDrawer so we don't need to do this
-        let item = root;
-        while ((item = item.parent)) {
-            if (item instanceof Flickable) {
-                item.interactive = false;
+    delegate: Kirigami.BasicListItem {
+        id: listItem
+        property var feed: model.feed
+        property var iconName: feed ? feed.icon.toString() : ""
+        property var status: feed ? feed.status : Feed.Idle
+        property var unreadCount: feed ? feed.unreadCount : 0
+        icon: iconName.length ? "image://feedicons/"+iconName : "feed-subscribe"
+        label: feed ? feed.name : ""
+        separatorVisible: false
+        padding: Kirigami.Units.largeSpacing
+        leftPadding: Kirigami.Units.smallSpacing
+        rightPadding: Kirigami.Units.smallSpacing
+        trailing: RowLayout {
+            Kirigami.Icon {
+                source: "content-loading-symbolic-nomask"
+                Layout.preferredHeight: contentItem.height
+                visible: listItem.status === Feed.Updating
+                selected: listItem.highlighted
+            }
+
+            Kirigami.Icon {
+                source: "dialog-error-symbolic-nomask"
+                Layout.preferredHeight: contentItem.height
+                visible: listItem.status === Feed.Error
+                selected: listItem.highlighted
+            }
+
+            Label {
+                id: unreadCountLabel
+                visible: listItem.unreadCount !== 0
+                horizontalAlignment: Text.AlignCenter
+                Layout.rightMargin: background.radius
+                text: listItem.unreadCount
+                leftInset: -background.radius
+                rightInset: -background.radius
+                background: Rectangle {
+                    radius: parent.height / 2.0
+                    color: Kirigami.Theme.activeBackgroundColor;
+                }
             }
         }
+
+        onClicked: root.itemClicked()
+
+        Component.onCompleted: console.log("created "+feed.name)
+    }/* delegate */
+
+    section.property: "category"
+    section.delegate: Kirigami.ListSectionHeader {
+        label: section
+        topPadding: padding * 2
+        bottomPadding: padding * 2
+        onClicked: {
+            currentIndex = -1
+            root.currentlySelectedFeed = feedContext.createCategoryFeed(section);
+            root.itemClicked();
+        }
+    }
+
+    move: Transition {
+        enabled: root.visible
+        NumberAnimation { properties: "x, y"; duration: Kirigami.Units.shortDuration }
+    }
+
+    displaced: Transition {
+        enabled: root.visible
+        NumberAnimation { properties: "x, y"; duration: Kirigami.Units.shortDuration }
+    }
+
+    onCurrentItemChanged: {
+        if (currentItem)
+            root.currentlySelectedFeed = currentItem.feed;
     }
 
     function selectFeed(feed) {
-        feedList.forceLayout()
-        feedList.currentIndex = feedListModel.indexOf(feed)
+        root.forceLayout()
+        root.currentIndex = feedListModel.indexOf(feed)
     }
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -64,9 +64,10 @@ Kirigami.ApplicationWindow {
 
             FeedList {
                 id: feedList
+                interactive: false
                 Layout.fillHeight: true
                 Layout.fillWidth: true
-                Layout.preferredHeight: drawer.height
+                Layout.minimumHeight: contentHeight
                 onCurrentlySelectedFeedChanged:
                     if (currentlySelectedFeed) priv.pushFeed(currentlySelectedFeed)
 


### PR DESCRIPTION
It is not necessary for e.g. settings, about to be so prominent in the UI, since they're accessed relatively rarely.  This moves them to the bottom of the feed list instead of giving them a reserved space in the drawer.  

This also avoids some buggy behavior that results from nesting our own scrollview inside of the one provided by Kirigami.GlobalDrawer (#34) and prevents touch-mode action item padding (#15) taking space away from the feed list.