### PR TITLE
Remove old page row animation hack

### DIFF
--- a/src/qml/ArticleList/AbstractArticleListPage.qml
+++ b/src/qml/ArticleList/AbstractArticleListPage.qml
@@ -68,9 +68,6 @@ Kirigami.ScrollablePage {
         id: pageOpenTimer
         interval: 0
         onTriggered: {
-            if (pageRow.wideMode) {
-                root.Window.window.suspendAnimations();
-            }
             pageRow.currentIndex = root.Kirigami.ColumnView.index
             if (childPage) {
                 root.pageRow.push(childPage, {articleListController: articleListController})

--- a/src/qml/ArticlePage.qml
+++ b/src/qml/ArticlePage.qml
@@ -158,18 +158,15 @@ Kirigami.Page {
             if (!swipeView.currentItem.atYEnd) {
                 swipeView.currentItem.pageUpDown(0.9);
             } else {
-                root.Window.window.suspendAnimations();
                 articleListController.nextItem();
             }
             break;
 
         case Qt.Key_Left:
-            root.Window.window.suspendAnimations();
             articleListController.previousItem();
             break;
 
         case Qt.Key_Right:
-            root.Window.window.suspendAnimations();
             articleListController.nextItem();
             break;
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -189,11 +189,6 @@ Kirigami.ApplicationWindow {
 
     }
 
-    Timer {
-        id: animationSuspendTimer
-        interval: Kirigami.Units.longDuration
-    }
-
     Connections {
         target: pageStack.currentItem
         ignoreUnknownSignals: true
@@ -238,9 +233,5 @@ Kirigami.ApplicationWindow {
 
     function selectFeed(feed) {
         feedList.selectFeed(feed);
-    }
-
-    function suspendAnimations() {
-        animationSuspendTimer.start();
     }
 }


### PR DESCRIPTION
We had been using a timer to disable animations on the page row in order to avoid spurious animations when navigating between articles, but with the article page refactor that's no longer necessary.