### PR TITLE
Replace hand-rolled Future implementation with QPromise/QFuture

### DIFF
--- a/feedcore/aggregatefeed.h
+++ b/feedcore/aggregatefeed.h
@@ -17,7 +17,7 @@ class AggregateFeed : public FeedCore::Feed
 public:
     explicit AggregateFeed(QObject *parent = nullptr);
     FeedCore::Feed::Updater *updater() override;
-    FeedCore::Future<FeedCore::ArticleRef> *getArticles(bool unreadOnly) override;
+    QFuture<FeedCore::ArticleRef> getArticles(bool unreadOnly) override;
 
 protected:
     void addFeed(Feed *feed);

--- a/feedcore/article.h
+++ b/feedcore/article.h
@@ -104,7 +104,7 @@ public:
      *
      * The default implementation returns nullptr.
      */
-    virtual FeedCore::Future<QString> *getCachedReadableContent();
+    virtual QFuture<QString> getCachedReadableContent();
 
     /**
      * Resolves a link relative to the article page

--- a/feedcore/context.h
+++ b/feedcore/context.h
@@ -128,13 +128,13 @@ public:
      *
      * @return A future representing the list of articles.
      */
-    Future<ArticleRef> *getArticles(bool unreadFilter);
+    QFuture<ArticleRef> getArticles(bool unreadFilter);
 
     /**
      * List starred articles stored in this context (isStarred == true).
      * @return A future representing the list of articles
      */
-    Future<ArticleRef> *getStarred();
+    QFuture<ArticleRef> getStarred();
 
     /**
      * Trigger an update on every feed in this context.

--- a/feedcore/feed.cpp
+++ b/feedcore/feed.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "feed.h"
+#include <QTimer>
 using namespace FeedCore;
 
 struct Feed::PrivData {

--- a/feedcore/feed.h
+++ b/feedcore/feed.h
@@ -4,6 +4,7 @@
  */
 
 #pragma once
+#include "articleref.h"
 #include "future.h"
 #include <QDateTime>
 #include <QObject>
@@ -134,7 +135,7 @@ public:
      *
      * If unreadFilter is true, only unread articles are returned.
      */
-    virtual Future<ArticleRef> *getArticles(bool unreadFilter) = 0;
+    virtual QFuture<ArticleRef> getArticles(bool unreadFilter) = 0;
 
     virtual Updater *updater() = 0;
 

--- a/feedcore/provisionalfeed.cpp
+++ b/feedcore/provisionalfeed.cpp
@@ -41,15 +41,15 @@ ProvisionalFeed::ProvisionalFeed(QObject *parent)
     });
 }
 
-Future<ArticleRef> *ProvisionalFeed::getArticles(bool /* unreadFilter */)
+QFuture<ArticleRef> ProvisionalFeed::getArticles(bool /* unreadFilter */)
 {
-    return Future<ArticleRef>::yield(this, [this](auto *op) {
+    return Future::yield<ArticleRef>(this, [this](auto &op) {
         if (m_feed == nullptr) {
             return;
         }
         const auto &items = m_feed->items();
         for (const auto &item : items) {
-            op->appendResult(m_articles.getInstance(item, this));
+            op.addResult(m_articles.getInstance(item, this));
         }
     });
 }

--- a/feedcore/provisionalfeed.h
+++ b/feedcore/provisionalfeed.h
@@ -67,7 +67,7 @@ public:
         return m_urlStringStatus;
     }
 
-    Future<ArticleRef> *getArticles(bool unreadFilter) final;
+    QFuture<ArticleRef> getArticles(bool unreadFilter) final;
 
     Feed *targetFeed() const;
     void setTargetFeed(Feed *targetFeed);

--- a/feedcore/scheduler.cpp
+++ b/feedcore/scheduler.cpp
@@ -6,6 +6,7 @@
 #include "scheduler.h"
 #include "feed.h"
 #include <QSet>
+#include <QTimer>
 
 namespace FeedCore
 {

--- a/feedcore/starreditemsfeed.cpp
+++ b/feedcore/starreditemsfeed.cpp
@@ -29,7 +29,7 @@ StarredItemsFeed::StarredItemsFeed(FeedCore::Context *context, const QString &na
     setName(name);
 }
 
-Future<ArticleRef> *StarredItemsFeed::getArticles(bool /*unused*/)
+QFuture<ArticleRef> StarredItemsFeed::getArticles(bool /*unused*/)
 {
     return m_context->getStarred();
 }

--- a/feedcore/starreditemsfeed.h
+++ b/feedcore/starreditemsfeed.h
@@ -17,7 +17,7 @@ class StarredItemsFeed : public Feed
 {
 public:
     StarredItemsFeed(Context *context, const QString &name, QObject *parent = nullptr);
-    Future<ArticleRef> *getArticles(bool unreadFilter) final;
+    QFuture<ArticleRef> getArticles(bool unreadFilter) final;
     Updater *updater() final;
 
 private:

--- a/feedcore/storage.h
+++ b/feedcore/storage.h
@@ -4,6 +4,7 @@
  */
 
 #pragma once
+#include "articleref.h"
 #include "future.h"
 #include <QObject>
 #include <Syndication/Feed>
@@ -19,10 +20,10 @@ class Storage : public QObject
 public:
     explicit Storage(QObject *parent = nullptr)
         : QObject(parent){};
-    virtual Future<ArticleRef> *getAll() = 0;
-    virtual Future<ArticleRef> *getUnread() = 0;
-    virtual Future<ArticleRef> *getStarred() = 0;
-    virtual Future<Feed *> *getFeeds() = 0;
-    virtual Future<Feed *> *storeFeed(Feed *feed) = 0;
+    virtual QFuture<ArticleRef> getAll() = 0;
+    virtual QFuture<ArticleRef> getUnread() = 0;
+    virtual QFuture<ArticleRef> getStarred() = 0;
+    virtual QFuture<Feed *> getFeeds() = 0;
+    virtual QFuture<Feed *> storeFeed(Feed *feed) = 0;
 };
 }

--- a/sqlite/articleimpl.cpp
+++ b/sqlite/articleimpl.cpp
@@ -48,13 +48,13 @@ void ArticleImpl::requestContent()
     if (m_storage.isNull()) {
         return;
     }
-    Future<QString> *fut = m_storage->getContent(this);
-    QObject::connect(fut, &BaseFuture::finished, this, [this, fut] {
-        emit gotContent(fut->result().first());
+    QFuture<QString> fut = m_storage->getContent(this);
+    Future::safeThen(fut, this, [this](auto &fut) {
+        emit gotContent(fut.result());
     });
 }
 
-FeedCore::Future<QString> *ArticleImpl::getCachedReadableContent()
+QFuture<QString> ArticleImpl::getCachedReadableContent()
 {
     return m_storage->getReadableContent(this);
 }

--- a/sqlite/articleimpl.h
+++ b/sqlite/articleimpl.h
@@ -21,7 +21,7 @@ public:
     qint64 id() const;
     void updateFromQuery(const ItemQuery &q);
     void requestContent() final;
-    FeedCore::Future<QString> *getCachedReadableContent() final;
+    QFuture<QString> getCachedReadableContent() final;
     void cacheReadableContent(const QString &readableContent) final;
 
 private:

--- a/sqlite/feedimpl.h
+++ b/sqlite/feedimpl.h
@@ -24,7 +24,7 @@ class FeedImpl : public FeedCore::UpdatableFeed
 public:
     qint64 id() const;
     void updateFromQuery(const FeedQuery &query);
-    FeedCore::Future<FeedCore::ArticleRef> *getArticles(bool unreadFilter) final;
+    QFuture<FeedCore::ArticleRef> getArticles(bool unreadFilter) final;
     bool editable() final
     {
         return true;

--- a/sqlite/storageimpl.h
+++ b/sqlite/storageimpl.h
@@ -19,21 +19,21 @@ class StorageImpl : public FeedCore::Storage
 public:
     explicit StorageImpl(const QString &filePath);
     ~StorageImpl();
-    FeedCore::Future<FeedCore::ArticleRef> *getById(qint64 id);
-    FeedCore::Future<FeedCore::ArticleRef> *getByFeed(FeedImpl *feedId);
-    FeedCore::Future<FeedCore::ArticleRef> *getUnreadByFeed(FeedImpl *feedId);
-    FeedCore::Future<FeedCore::ArticleRef> *storeArticle(FeedImpl *feed, const Syndication::ItemPtr &item);
-    FeedCore::Future<QString> *getContent(ArticleImpl *article);
-    FeedCore::Future<QString> *getReadableContent(ArticleImpl *article);
+    QFuture<FeedCore::ArticleRef> getById(qint64 id);
+    QFuture<FeedCore::ArticleRef> getByFeed(FeedImpl *feedId);
+    QFuture<FeedCore::ArticleRef> getUnreadByFeed(FeedImpl *feedId);
+    QFuture<FeedCore::ArticleRef> storeArticle(FeedImpl *feed, const Syndication::ItemPtr &item);
+    QFuture<QString> getContent(ArticleImpl *article);
+    QFuture<QString> getReadableContent(ArticleImpl *article);
     void cacheReadableContent(ArticleImpl *article, const QString &readableContent);
     void onArticleReadChanged(ArticleImpl *article);
     void onArticleStarredChanged(ArticleImpl *article);
 
-    FeedCore::Future<FeedCore::ArticleRef> *getAll() final;
-    FeedCore::Future<FeedCore::ArticleRef> *getUnread() final;
-    FeedCore::Future<FeedCore::ArticleRef> *getStarred() final;
-    FeedCore::Future<FeedCore::Feed *> *getFeeds() final;
-    FeedCore::Future<FeedCore::Feed *> *storeFeed(FeedCore::Feed *feed) final;
+    QFuture<FeedCore::ArticleRef> getAll() final;
+    QFuture<FeedCore::ArticleRef> getUnread() final;
+    QFuture<FeedCore::ArticleRef> getStarred() final;
+    QFuture<FeedCore::Feed *> getFeeds() final;
+    QFuture<FeedCore::Feed *> storeFeed(FeedCore::Feed *feed) final;
     void listenForChanges(FeedImpl *feed);
     void expire(FeedImpl *feed, const QDateTime &olderThan);
 
@@ -45,17 +45,17 @@ private:
     FeedCore::ObjectFactory<qint64, FeedImpl> m_feedFactory;
     FeedCore::SharedFactory<qint64, ArticleImpl> m_articleFactory;
     bool m_hasTransaction{false};
-    void appendFeedResults(FeedCore::Future<FeedCore::Feed *> *op, FeedQuery &q);
-    void appendArticleResults(FeedCore::Future<FeedCore::ArticleRef> *op, ItemQuery &q);
+    void appendFeedResults(QPromise<FeedCore::Feed *> &op, FeedQuery &q);
+    void appendArticleResults(QPromise<FeedCore::ArticleRef> &op, ItemQuery &q);
     void onFeedRequestDelete(FeedImpl *feed);
     void ensureTransaction();
     const static int CommitEvent;
 
     template<typename Payload, typename Func>
-    FeedCore::Future<Payload> *runInTransaction(Func func)
+    QFuture<Payload> runInTransaction(Func func)
     {
         ensureTransaction();
-        return FeedCore::Future<Payload>::yield(this, func);
+        return FeedCore::Future::yield<Payload>(this, func);
     }
 };
 }

--- a/src/articlelistmodel.cpp
+++ b/src/articlelistmodel.cpp
@@ -7,6 +7,7 @@
 #include "articleref.h"
 #include "feed.h"
 #include "qmlarticleref.h"
+#include <QTimer>
 #include <algorithm>
 
 using namespace FeedCore;
@@ -288,9 +289,9 @@ void ArticleListModel::getItems(Callback cb)
         cb(QVector<ArticleRef>{});
         return;
     }
-    Future<ArticleRef> *q = d->feed->getArticles(unreadFilter());
-    QObject::connect(q, &BaseFuture::finished, this, [this, cb, q] {
-        auto result = q->result();
+    QFuture<ArticleRef> q = d->feed->getArticles(unreadFilter());
+    Future::safeThen(q, this, [this, cb](auto &q) {
+        auto result = Future::safeResults(q);
         if (unreadFilter()) {
             removeReadArticles(result);
         }

--- a/src/feedlistmodel.cpp
+++ b/src/feedlistmodel.cpp
@@ -9,6 +9,7 @@
 #include "starreditemsfeed.h"
 #include <QPointer>
 #include <QString>
+#include <QTimer>
 #include <QVector>
 #include <algorithm>
 

--- a/test/mockfeed.h
+++ b/test/mockfeed.h
@@ -26,10 +26,12 @@ public:
         return &m_updater;
     }
 
-    FeedCore::Future<FeedCore::ArticleRef> *getArticles(bool /*unreadFilter*/) override
+    QFuture<FeedCore::ArticleRef> getArticles(bool /*unreadFilter*/) override
     {
-        return FeedCore::Future<FeedCore::ArticleRef>::yield(this, [this](auto *op) {
-            op->setResult(QVector<FeedCore::ArticleRef>(m_articles));
+        return FeedCore::Future::yield<FeedCore::ArticleRef>(this, [this](auto &op) {
+            for (const auto &item : std::as_const(m_articles)) {
+                op.addResult(item);
+            }
         });
     }
 

--- a/test/mockstorage.h
+++ b/test/mockstorage.h
@@ -8,58 +8,60 @@ class MockStorage : public FeedCore::Storage
 public:
     QVector<MockFeed *> m_feeds;
 
-    FeedCore::Future<FeedCore::ArticleRef> *getAll() override
+    QFuture<FeedCore::ArticleRef> getAll() override
     {
-        return FeedCore::Future<FeedCore::ArticleRef>::yield(this, [this](auto *op) {
+        return FeedCore::Future::yield<FeedCore::ArticleRef>(this, [this](auto &op) {
             for (auto *feed : m_feeds) {
                 for (auto &ar : std::as_const(feed->m_articles)) {
-                    op->appendResult(ar);
+                    op.addResult(ar);
                 }
             }
         });
     }
 
-    FeedCore::Future<FeedCore::ArticleRef> *getUnread() override
+    QFuture<FeedCore::ArticleRef> getUnread() override
     {
-        return FeedCore::Future<FeedCore::ArticleRef>::yield(this, [this](auto *op) {
+        return FeedCore::Future::yield<FeedCore::ArticleRef>(this, [this](auto &op) {
             for (auto *feed : m_feeds) {
                 for (auto &ar : std::as_const(feed->m_articles)) {
                     if (!ar->isRead()) {
-                        op->appendResult(ar);
+                        op.addResult(ar);
                     }
                 }
             }
         });
     }
 
-    FeedCore::Future<FeedCore::ArticleRef> *getStarred() override
+    QFuture<FeedCore::ArticleRef> getStarred() override
     {
-        return FeedCore::Future<FeedCore::ArticleRef>::yield(this, [this](auto *op) {
+        return FeedCore::Future::yield<FeedCore::ArticleRef>(this, [this](auto &op) {
             for (auto *feed : m_feeds) {
                 for (auto &ar : std::as_const(feed->m_articles)) {
                     if (!ar->isStarred()) {
-                        op->appendResult(ar);
+                        op.addResult(ar);
                     }
                 }
             }
         });
     }
 
-    FeedCore::Future<FeedCore::Feed *> *getFeeds() override
+    QFuture<FeedCore::Feed *> getFeeds() override
     {
-        return FeedCore::Future<FeedCore::Feed *>::yield(this, [this](auto *op) {
-            op->setResult(QVector<FeedCore::Feed *>(m_feeds.cbegin(), m_feeds.cend()));
+        return FeedCore::Future::yield<FeedCore::Feed *>(this, [this](auto &op) {
+            for (auto &item : std::as_const(m_feeds)) {
+                op.addResult(item);
+            }
         });
     }
 
-    FeedCore::Future<FeedCore::Feed *> *storeFeed(FeedCore::Feed *feed) override
+    QFuture<FeedCore::Feed *> storeFeed(FeedCore::Feed *feed) override
     {
         MockFeed *newFeed = new MockFeed;
         newFeed->setParent(this);
         newFeed->updateParams(feed);
         m_feeds << newFeed;
-        return FeedCore::Future<FeedCore::Feed *>::yield(newFeed, [newFeed](auto *op) {
-            op->setResult(newFeed);
+        return FeedCore::Future::yield<FeedCore::Feed *>(newFeed, [newFeed](auto &op) {
+            op.addResult(newFeed);
         });
     }
 };

--- a/test/tst_allitemsfeed.cpp
+++ b/test/tst_allitemsfeed.cpp
@@ -60,13 +60,14 @@ private slots:
         allItems << m_mockFeed2->m_articles;
         std::sort(allItems.begin(), allItems.end());
 
-        auto *getArticles = m_allItemsFeed->getArticles(false);
+        auto getArticles = m_allItemsFeed->getArticles(false);
         QVector<ArticleRef> aafItems;
-        QObject::connect(getArticles, &BaseFuture::finished, this, [getArticles, &aafItems] {
-            aafItems = getArticles->result();
+        FeedCore::Future::safeThen(getArticles, this, [&aafItems](auto &getArticles) {
+            aafItems = Future::safeResults(getArticles);
         });
-        QSignalSpy waitArticles(getArticles, &FeedCore::BaseFuture::finished);
-        waitArticles.wait();
+        QVERIFY(QTest::qWaitFor([&] {
+            return getArticles.isFinished();
+        }));
         std::sort(aafItems.begin(), aafItems.end());
         QVERIFY(allItems == aafItems);
     }
@@ -79,13 +80,14 @@ private slots:
         QVector<ArticleRef> unreadItems = {m_mockFeed1->m_articles[1], m_mockFeed2->m_articles[0]};
         std::sort(unreadItems.begin(), unreadItems.end());
 
-        auto *getArticles = m_allItemsFeed->getArticles(true);
+        auto getArticles = m_allItemsFeed->getArticles(true);
         QVector<ArticleRef> aafItems;
-        QObject::connect(getArticles, &BaseFuture::finished, this, [getArticles, &aafItems] {
-            aafItems = getArticles->result();
+        FeedCore::Future::safeThen(getArticles, this, [&aafItems](auto &getArticles) {
+            aafItems = Future::safeResults(getArticles);
         });
-        QSignalSpy waitArticles(getArticles, &FeedCore::BaseFuture::finished);
-        waitArticles.wait();
+        QVERIFY(QTest::qWaitFor([&] {
+            return getArticles.isFinished();
+        }));
         std::sort(aafItems.begin(), aafItems.end());
         QVERIFY(unreadItems == aafItems);
     }

--- a/test/tst_testcontextvaluepropagation.cpp
+++ b/test/tst_testcontextvaluepropagation.cpp
@@ -17,31 +17,32 @@ class MockStorage : public FeedCore::Storage
     QVector<Feed *> m_feeds;
 
 public:
-    Future<FeedCore::ArticleRef> *getAll() override
+    QFuture<FeedCore::ArticleRef> getAll() override
     {
-        return Future<ArticleRef>::yield(this, [](auto) {});
+        return Future::yield<ArticleRef>(this, [](auto &) {});
     }
 
-    Future<FeedCore::ArticleRef> *getUnread() override
+    QFuture<FeedCore::ArticleRef> getUnread() override
     {
-        return Future<ArticleRef>::yield(this, [](auto) {});
+        return Future::yield<ArticleRef>(this, [](auto &) {});
     }
-    Future<FeedCore::ArticleRef> *getStarred() override
+    QFuture<FeedCore::ArticleRef> getStarred() override
     {
-        return Future<ArticleRef>::yield(this, [](auto) {});
+        return Future::yield<ArticleRef>(this, [](auto &) {});
     }
-    Future<FeedCore::Feed *> *getFeeds() override
+    QFuture<FeedCore::Feed *> getFeeds() override
     {
-        return Future<Feed *>::yield(this, [this](auto r) {
-            QVector<Feed *> feeds = m_feeds;
-            r->setResult(std::move(feeds));
+        return Future::yield<Feed *>(this, [this](auto &r) {
+            for (const auto &item : std::as_const(m_feeds)) {
+                r.addResult(item);
+            }
         });
     }
-    Future<FeedCore::Feed *> *storeFeed(FeedCore::Feed *feed) override
+    QFuture<FeedCore::Feed *> storeFeed(FeedCore::Feed *feed) override
     {
         m_feeds.append(feed);
-        return Future<Feed *>::yield(this, [feed](auto r) {
-            r->setResult(feed);
+        return Future::yield<Feed *>(this, [feed](auto &r) {
+            r.addResult(feed);
         });
     }
 };


### PR DESCRIPTION
We were previously using a QObject class to represent async operations, but Qt6 has QPromise, which does everything our implementation did and more, without the overhead of a new QObject and a signal/slot connection for every operation. It's also better tested code that we don't have to maintain.

This touches a lot of code, but it's mostly just a find-and-replace job.

Note that future.h contains some new convenience functions that mimic the behavior of our old Future class. These are there to avoid having to refactor every existing consumer, but they should probably be avoided in new code.