### PR TITLE
Enable HTTP/2 on Qt6

### DIFF
--- a/feedcore/networkaccessmanager.cpp
+++ b/feedcore/networkaccessmanager.cpp
@@ -174,7 +174,6 @@ QNetworkReply *FeedCore::NetworkAccessManager::createRequest(QNetworkAccessManag
     QNetworkRequest newRequest(request);
     newRequest.setHeader(QNetworkRequest::UserAgentHeader, "syndic/1.0");
     setDefaultAttribute(newRequest, QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
-    setDefaultAttribute(newRequest, QNetworkRequest::Http2AllowedAttribute, false);
     newRequest.setTransferTimeout();
 
     // We don't want to keep connections open since we make one-shot downloads

--- a/src/contentimageitem.h
+++ b/src/contentimageitem.h
@@ -54,9 +54,7 @@ private:
     QNetworkReply *m_reply{nullptr};
     LoadStatus m_loadStatus{Loading};
 
-    enum ImageLoadFlags { None = 0, UseHttp2Flag = 1 };
-
-    void beginImageLoad(ImageLoadFlags flags = None);
+    void beginImageLoad();
     void cancelImageLoad();
     void onImageLoadFinished();
     void setLoadStatus(LoadStatus v);


### PR DESCRIPTION
I had explicitly set HTTP2EnabledAttribute=false it in 297ef3e67a0c0003cb66f7d180e8de2b8eeeb0b1 for consistency during the Qt5-Qt6 migration.

However, allowing HTTP/2 allows us to get rid of a hacky workaround in ContentImageItem and fixes the related error in #156.