### PR TITLE
Use declarative properties to populate pagerow

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(syndic_HEADERS
     contentimageitem.h
     application.h
     networkaccessmanagerfactory.h
+    pagecontrolattached.h
     )
 
 set(syndic_SRCS
@@ -27,6 +28,7 @@ set(syndic_SRCS
     platformhelper.cpp
     contentimageitem.cpp
     networkaccessmanagerfactory.cpp
+    pagecontrolattached.cpp
     application.cpp
     main.cpp
     resources.qrc

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -25,6 +25,7 @@
 #include "iconprovider.h"
 #include "networkaccessmanagerfactory.h"
 #include "notificationcontroller.h"
+#include "pagecontrolattached.h"
 #include "platformhelper.h"
 #include "provisionalfeed.h"
 #include "qmlarticleref.h"
@@ -75,6 +76,7 @@ static void registerQmlTypes()
     qmlRegisterUncreatableType<ContentBlock>("com.rocksandpaper.syndic", 1, 0, "ContentBlock", "obtained from contentmodel");
     qmlRegisterUncreatableType<ImageBlock>("com.rocksandpaper.syndic", 1, 0, "ImageBlock", "obtained from contentmodel");
     qmlRegisterUncreatableType<TextBlock>("com.rocksandpaper.syndic", 1, 0, "TextBlock", "obtained from contentmodel");
+    qmlRegisterUncreatableType<PageControlAttached>("com.rocksandpaper.syndic", 1, 0, "PageControl", "attached object");
 }
 
 static void enableSettingsAutosave(const Settings &settings)

--- a/src/pagecontrolattached.cpp
+++ b/src/pagecontrolattached.cpp
@@ -1,0 +1,74 @@
+#include "pagecontrolattached.h"
+#include <QVariant>
+
+PageControlAttached::PageControlAttached(QObject *parent)
+    : QObject(parent)
+{
+}
+
+PageSpec PageControlAttached::nextPage() const
+{
+    return m_nextPage;
+}
+
+void PageControlAttached::setNextPage(const PageSpec &newPageSpec)
+{
+    if (m_nextPage == newPageSpec)
+        return;
+    m_nextPage = newPageSpec;
+    emit nextPageChanged();
+    sync();
+}
+
+void PageControlAttached::sync()
+{
+    if (!m_pageController) {
+        return;
+    }
+    QObject *attachedTo = this->parent();
+    QMetaObject::invokeMethod(m_pageController, "sync", Qt::DirectConnection, Q_ARG(QVariant, QVariant::fromValue(attachedTo)));
+}
+
+QObject *PageControlAttached::pageController() const
+{
+    return m_pageController;
+}
+
+void PageControlAttached::setPageController(QObject *newPageController)
+{
+    if (m_pageController != newPageController) {
+        m_pageController = newPageController;
+        emit pageControllerChanged();
+    }
+}
+
+QString PageSpec::componentName() const
+{
+    return m_componentName;
+}
+
+void PageSpec::setComponentName(const QString &newComponentName)
+{
+    if (m_componentName == newComponentName) {
+        return;
+    }
+    m_componentName = newComponentName;
+}
+
+QJSValue PageSpec::pageData() const
+{
+    return m_pageData;
+}
+
+void PageSpec::setPageData(const QJSValue &newPageData)
+{
+    if (m_pageData.strictlyEquals(newPageData)) {
+        return;
+    }
+    m_pageData = newPageData;
+}
+
+bool PageSpec::operator==(const PageSpec &other)
+{
+    return m_componentName == other.componentName() && m_pageData.strictlyEquals(other.pageData());
+}

--- a/src/pagecontrolattached.h
+++ b/src/pagecontrolattached.h
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include "qqmlintegration.h"
+#include <QJSValue>
+#include <QObject>
+#include <QPointer>
+
+class PageSpec
+{
+    Q_GADGET
+    Q_PROPERTY(QString componentName READ componentName WRITE setComponentName)
+    Q_PROPERTY(QJSValue pageData READ pageData WRITE setPageData)
+
+public:
+    QString componentName() const;
+    void setComponentName(const QString &newComponentName);
+
+    QJSValue pageData() const;
+    void setPageData(const QJSValue &newPageData);
+
+    bool operator==(const PageSpec &other);
+
+private:
+    QString m_componentName;
+    QJSValue m_pageData;
+};
+Q_DECLARE_METATYPE(PageSpec);
+
+class PageControlAttached : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QObject *pageController READ pageController NOTIFY pageControllerChanged)
+    Q_PROPERTY(PageSpec nextPage READ nextPage WRITE setNextPage NOTIFY nextPageChanged)
+    QML_ATTACHED(PageControlAttached)
+
+public:
+    QObject *pageController() const;
+    Q_INVOKABLE void setPageController(QObject *newPageController);
+    PageSpec nextPage() const;
+    void setNextPage(const PageSpec &newPageSpec);
+    Q_INVOKABLE void sync();
+
+    static PageControlAttached *qmlAttachedProperties(QObject *object)
+    {
+        return new PageControlAttached(object);
+    }
+
+signals:
+    void pageControllerChanged();
+    void nextPageChanged();
+
+private:
+    explicit PageControlAttached(QObject *parent);
+
+    PageSpec m_nextPage;
+    QPointer<QObject> m_pageController;
+};

--- a/src/qml/AddFeedPage.qml
+++ b/src/qml/AddFeedPage.qml
@@ -13,6 +13,11 @@ AbstractFeedEditorPage {
     property bool previewOpen: false
     property bool keepDrawerOpen: true
     title: qsTr("Add Content")
+    PageControl.nextPage {
+        componentName: root.previewOpen ? "qrc:/qml/ArticleList/FeedPreviewPage.qml" : ""
+        pageData: ({provisionalFeed: root.provisionalFeed,
+                                        pageRow: root.pageRow})
+    }
 
     provisionalFeed: ProvisionalFeed {
         updateMode: Feed.InheritUpdateMode
@@ -35,19 +40,6 @@ AbstractFeedEditorPage {
             onToggled: previewOpen = checked
         }
     ]
-
-    onPreviewOpenChanged: {
-        if (previewOpen) {
-            provisionalFeed.updater.start()
-            pageRow.currentIndex = Kirigami.ColumnView.index
-            pageRow.push("qrc:/qml/ArticleList/FeedPreviewPage.qml",
-                         {provisionalFeed: root.provisionalFeed,
-                          pageRow: root.pageRow});
-            previewOpen = true;
-        } else {
-            pageRow.pop(this);
-        }
-    }
 
     Keys.onReturnPressed: previewOpen = true
     Keys.onEnterPressed: previewOpen = true

--- a/src/qml/ArticleList/AbstractArticleListPage.qml
+++ b/src/qml/ArticleList/AbstractArticleListPage.qml
@@ -20,23 +20,26 @@ Kirigami.ScrollablePage {
     property bool isUpdating: model.status === Feed.Updating
     property bool unreadFilter: true
     property bool automaticOpen: pageRow.defaultColumnWidth * 2 < pageRow.width
-    property string childPage: {
-        if (articleList.currentItem) {
-            return "qrc:/qml/ArticlePage.qml"
-        } else if (model && automaticOpen) {
-            switch(model.status) {
-            case Feed.Loading:
-                return ""
-            case Feed.Updating:
-                return "qrc:/qml/Placeholders/UpdatingPlaceholderPage.qml";
-            case Feed.Error:
-                return "qrc:/qml/Placeholders/ErrorPlaceholderPage.qml";
-            default:
-                return "qrc:/qml/Placeholders/EmptyFeedPlaceholderPage.qml";
+    PageControl.nextPage {
+        componentName: {
+            if (articleList.currentItem) {
+                return "qrc:/qml/ArticlePage.qml"
+            } else if (model && automaticOpen) {
+                switch(model.status) {
+                case Feed.Loading:
+                    return ""
+                case Feed.Updating:
+                    return "qrc:/qml/Placeholders/UpdatingPlaceholderPage.qml";
+                case Feed.Error:
+                    return "qrc:/qml/Placeholders/ErrorPlaceholderPage.qml";
+                default:
+                    return "qrc:/qml/Placeholders/EmptyFeedPlaceholderPage.qml";
+                }
+            } else {
+                return "";
             }
-        } else {
-            return "";
         }
+        pageData: ({articleListController: articleListController})
     }
 
     supportsRefreshing: true
@@ -62,19 +65,6 @@ Kirigami.ScrollablePage {
         }
 
         function previousItem () { articleList.currentIndex-- }
-    }
-
-    Timer {
-        id: pageOpenTimer
-        interval: 0
-        onTriggered: {
-            pageRow.currentIndex = root.Kirigami.ColumnView.index
-            if (childPage) {
-                root.pageRow.push(childPage, {articleListController: articleListController})
-            } else {
-                root.pageRow.pop(root);
-            }
-        }
     }
 
     ListView {
@@ -168,8 +158,6 @@ Kirigami.ScrollablePage {
             refreshing = Qt.binding(()=>isUpdating);
         }
     }
-
-    onChildPageChanged: pageOpenTimer.start()
 
     function clearRead() {
         root.currentIndex = -1

--- a/src/qml/ArticleList/FeedPreviewPage.qml
+++ b/src/qml/ArticleList/FeedPreviewPage.qml
@@ -32,4 +32,8 @@ AbstractArticleListPage {
             }
         }
     ]
+
+    Component.onCompleted: {
+        provisionalFeed.updater.start()
+    }
 }

--- a/src/qml/PageController.qml
+++ b/src/qml/PageController.qml
@@ -1,0 +1,57 @@
+import QtQuick 2.12
+import com.rocksandpaper.syndic 1.0
+import org.kde.kirigami 2.15 as Kirigami
+
+QtObject {
+    id: root
+    required property Kirigami.PageRow pageRow
+    property string firstPageComponent: ""
+    property var firstPageData: null
+
+    property list<QtObject> data: [
+        Connections {
+            target: root.pageRow
+
+            function onPagePushed(page) {
+                page.PageControl.setPageController(root);
+                pushNextPage(page);
+            }
+
+            function onPageRemoved(page) {
+                page.PageControl.setPageController(null);
+            }
+        }
+    ]
+
+    Component.onCompleted: {
+        pushFirstPage();
+        root.firstPageComponentChanged.connect(pushFirstPage);
+        root.firstPageDataChanged.connect(pushFirstPage);
+    }
+
+    function pushNextPage(thisPage) {
+        let pageComponent = thisPage.PageControl.nextPage.componentName
+        if (pageComponent) {
+            let pageData = thisPage.PageControl.nextPage.pageData
+            root.pageRow.push(pageComponent, pageData)
+        }
+    }
+
+    function pushFirstPage(pageComponent, pageData) {
+        if (!pageComponent) {
+            pageComponent = root.firstPageComponent;
+            pageData = root.firstPageData;
+        }
+        if (pageRow.depth) {
+            root.pageRow.currentIndex = 0;
+            root.pageRow.replace(pageComponent, pageData);
+        } else {
+            root.pageRow.push(pageComponent, pageData);
+        }
+    }
+
+    function sync(page) {
+        root.pageRow.pop(page);
+        pushNextPage(page);
+    }
+}

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -68,8 +68,6 @@ Kirigami.ApplicationWindow {
                 Layout.fillHeight: true
                 Layout.fillWidth: true
                 Layout.minimumHeight: contentHeight
-                onCurrentlySelectedFeedChanged:
-                    if (currentlySelectedFeed) priv.pushFeed(currentlySelectedFeed)
 
                 onItemClicked: {
                     if (pageStack.items[0] && pageStack.items[0].feedListAction) {
@@ -91,7 +89,7 @@ Kirigami.ApplicationWindow {
                 text: qsTr("Add Content")
                 icon.name: "list-add"
                 onTriggered: {
-                    priv.pushUtilityPage("qrc:/qml/AddFeedPage.qml", {pageRow: pageStack})
+                    priv.pushUtilityPage("qrc:/qml/AddFeedPage.qml", {pageRow: root.pageStack})
                 }
             },
             Kirigami.Action {
@@ -170,23 +168,12 @@ Kirigami.ApplicationWindow {
             }
         }
 
-        function pushRoot(pageUrl, pageProps) {
-            pageStack.currentIndex = 0;
-            pageStack[pageStack.depth ? "replace" : "push"](pageUrl, pageProps)
-        }
-
-        function pushFeed(feed) {
-            priv.pushRoot("qrc:/qml/ArticleList/ArticleListPage.qml",
-                           {pageRow: pageStack,
-                               feed: feed})
-        }
-
         function pushUtilityPage(pageUrl, pageProps) {
             feedList.currentIndex = -1
             feedList.currentlySelectedFeed = null
-            priv.pushRoot(pageUrl, pageProps)
-        }
+            pageController.pushFirstPage(pageUrl, pageProps)
 
+        }
     }
 
     Connections {
@@ -206,6 +193,13 @@ Kirigami.ApplicationWindow {
                 Qt.callLater(()=>priv.pushUtilityPage("qrc:/qml/AddFeedPage.qml", {pageRow: pageStack}))
             }
         }
+    }
+
+    PageController {
+        id: pageController
+        pageRow: root.pageStack
+        firstPageComponent: "qrc:/qml/ArticleList/ArticleListPage.qml"
+        firstPageData: ({pageRow: root.pageStack, feed: feedList.currentlySelectedFeed})
     }
 
     onClosing: {

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -24,5 +24,6 @@
         <file>qml/ElasticComboBox.qml</file>
         <file>qml/+org.kde.desktop/ElasticComboBox.qml</file>
         <file>qml/ArticlePageSwipeViewItem.qml</file>
+        <file>qml/PageController.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Introduce a new PageController class which consolidates all of the logic for pushing and popping pages from the page row into a single plage. The PageController has a property naming the root page component, and each page has a PageControl.nextPage attached property defining the page to appear after it in the page row.

This fixes #147 and makes it easier to consistently implement column view related bugfixes in the future.