### PR TITLE
Keyboard navigation: Home/End keys scroll to top/bottom of article

### DIFF
--- a/src/qml/ArticlePage.qml
+++ b/src/qml/ArticlePage.qml
@@ -186,6 +186,14 @@ Kirigami.Page {
             swipeView.currentItem.pageUpDown(0.9);
             break;
 
+        case Qt.Key_Home:
+            swipeView.currentItem.scrollToTop();
+            break;
+
+        case Qt.Key_End:
+            swipeView.currentItem.scrollToBottom();
+            break;
+
         case Qt.Key_Return:
         case Qt.Key_Enter:
             Qt.openUrlExternally(currentArticle.url);

--- a/src/qml/ArticlePageSwipeViewItem.qml
+++ b/src/qml/ArticlePageSwipeViewItem.qml
@@ -77,13 +77,27 @@ ScrollView {
         requestContent(true);
     }
 
+    function topY() {
+        return scroller.originY - scroller.topMargin;
+    }
+
+    function bottomY() {
+        return scroller.originY + scroller.contentHeight + scroller.bottomMargin - scroller.height;
+    }
+
     function pxUpDown(increment) {
-        const topY = scroller.originY - scroller.topMargin;
-        const bottomY = scroller.originY + scroller.contentHeight + scroller.bottomMargin - scroller.height;
-        scroller.contentY = Math.max(topY, Math.min(scroller.contentY + increment, bottomY))
+        scroller.contentY = Math.max(topY(), Math.min(scroller.contentY + increment, bottomY()))
     }
 
     function pageUpDown(increment) {
         pxUpDown(increment * scroller.height)
+    }
+
+    function scrollToTop() {
+        scroller.contentY = topY();
+    }
+
+    function scrollToBottom() {
+        scroller.contentY = bottomY();
     }
 }


### PR DESCRIPTION
This is the typical behavior in read-only applications like web browsing.

Previously we were falling back to the default TextEdit behavior of positioning the cursor at the beginning/end of the line, but that's meaningless for our purposes.