### PR TITLE
Restore missing category separators in feed list

### DIFF
--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -90,6 +90,7 @@ ListView {
         label: section
         topPadding: padding * 2
         bottomPadding: padding * 2
+        width: parent?.width > 0 ? parent.width : implicitWidth
         onClicked: {
             currentIndex = -1
             root.currentlySelectedFeed = feedContext.createCategoryFeed(section);


### PR DESCRIPTION
This used to be handled by ListSectionHeader via inheritance from AbstractListItem, but ListSectionHeader is no longer based on AbstractListItem, so we have to do it ourselves.