### PR TITLE
Don't defer when switching away from a deleted feed

### DIFF
--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -26,9 +26,7 @@ ListView {
         sortMode: globalSettings.feedListSort
 
         onRowsRemoved: {
-            Qt.callLater(()=>{
-                root.currentIndex = 0;
-            });
+            root.currentIndex = 0;
         }
     }
 


### PR DESCRIPTION
The deferred execution was there to fix this same issue on Qt5; it has the opposite effect on Qt6. This fixes the issue for now, but it's really just a band-aid until we can refactor page management.

Fixes #147