### PR TITLE
Don't close feed preview when URL is changed by feed discovery

### DIFF
--- a/feedcore/provisionalfeed.cpp
+++ b/feedcore/provisionalfeed.cpp
@@ -155,6 +155,7 @@ void ProvisionalFeed::setUrlString(const QString &newUrlString)
         m_urlStringStatus = INVALID;
     }
     emit urlStringChanged();
+    emit urlStringEdited();
 }
 
 void ProvisionalFeed::syncUrlString()

--- a/feedcore/provisionalfeed.h
+++ b/feedcore/provisionalfeed.h
@@ -80,6 +80,13 @@ signals:
     void urlStringChanged();
     void saveFailed();
 
+    /**
+     * This signal is similar to urlStringChanged, but is only emitted
+     * when the URL string is edited directly, and not when it changes
+     * because of Feed::setUrl(...)
+     */
+    void urlStringEdited();
+
 private:
     Feed *m_targetFeed{nullptr};
     Syndication::FeedPtr m_feed;

--- a/src/qml/AddFeedPage.qml
+++ b/src/qml/AddFeedPage.qml
@@ -20,7 +20,7 @@ AbstractFeedEditorPage {
         expireMode: Feed.InheritUpdateMode
         expireAge: globalSettings.expireAge
 
-        onUrlStringChanged: {
+        onUrlStringEdited: {
             previewOpen = false
         }
     }


### PR DESCRIPTION
Fixes #28 (again)