### PR TITLE
Allow building without QReadable for testing purposes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,10 @@ find_package(Qt6 COMPONENTS Core Qml Network Quick QuickControls2 Sql REQUIRED)
 find_package(KF6Syndication REQUIRED)
 find_package(KF6Config REQUIRED)
 find_package(KF6DBusAddons CONFIG QUIET)
+
+if (NOT WITHOUT_QREADABLE)
 find_package(QReadable REQUIRED)
+endif()
 
 if (ANDROID)
     set(BUILD_TESTING OFF)

--- a/cmake-config.h.template
+++ b/cmake-config.h.template
@@ -5,3 +5,4 @@
  
 #cmakedefine Qt6Widgets_FOUND
 #cmakedefine KF6DBusAddons_FOUND
+#cmakedefine QReadable_FOUND

--- a/feedcore/CMakeLists.txt
+++ b/feedcore/CMakeLists.txt
@@ -24,7 +24,6 @@ set(feedcore_HEADERS
     automation/automationrule.h
     readability/readability.h
     readability/readabilityresult.h
-    readability/qreadablereadability.h
     )
     
 set(feedcore_SRCS
@@ -45,9 +44,18 @@ set(feedcore_SRCS
     feeddiscovery.cpp
     automation/automationengine.cpp
     automation/automationrule.cpp
-    readability/qreadablereadability.cpp
     )
-    
+
+if (QReadable_FOUND)
+    set(feedcore_SRCS ${feedcore_SRCS}
+        readability/qreadablereadability.h
+        readability/qreadablereadability.cpp)
+else()
+    set(feedcore_SRCS ${feedcore_SRCS}
+        readability/placeholderreadability.h
+        readability/placeholderreadability.cpp)
+endif()
+
 add_library(feedcore STATIC ${feedcore_SRCS})
 ecm_create_qm_loader(feedcore feedcore)
 
@@ -56,6 +64,9 @@ target_link_libraries(feedcore
     Qt6::Sql
     Qt6::Network
     KF6::Syndication
-    QReadable::libqreadable
     htmlparser
 )
+
+if (QReadable_FOUND)
+    target_link_libraries(feedcore QReadable::libqreadable)
+endif()

--- a/feedcore/context.cpp
+++ b/feedcore/context.cpp
@@ -5,17 +5,25 @@
 #include "context.h"
 #include "automation/automationengine.h"
 #include "categoryfeed.h"
+#include "cmake-config.h"
 #include "feed.h"
 #include "future.h"
 #include "opmlreader.h"
 #include "provisionalfeed.h"
-#include "readability/qreadablereadability.h"
 #include "scheduler.h"
 #include "storage.h"
 #include <QDebug>
 #include <QFile>
 #include <QNetworkInformation>
 #include <QSet>
+
+#ifdef QReadable_FOUND
+#include "readability/qreadablereadability.h"
+using ReadabilityType = FeedCore::QReadableReadability;
+#else
+#include "readability/placeholderreadability.h"
+using ReadabilityType = FeedCore::PlaceholderReadability;
+#endif
 
 namespace FeedCore
 {
@@ -324,7 +332,7 @@ void Context::importOpml(const QUrl &url)
 Readability *Context::getReadability()
 {
     if (d->readability == nullptr) {
-        d->readability = new QReadableReadability();
+        d->readability = new ReadabilityType();
         d->readability->setParent(this);
     }
     return d->readability;

--- a/feedcore/context.h
+++ b/feedcore/context.h
@@ -173,6 +173,11 @@ public:
      */
     Q_INVOKABLE void importOpml(const QUrl &url);
 
+    /*
+     * Gets the Readability object for this context.
+     *
+     * This may be null if we were built without readability support
+     */
     Readability *getReadability();
 
     bool defaultUpdateEnabled() const;

--- a/feedcore/readability/placeholderreadability.cpp
+++ b/feedcore/readability/placeholderreadability.cpp
@@ -1,0 +1,22 @@
+#include "placeholderreadability.h"
+#include "readabilityresult.h"
+
+namespace FeedCore
+{
+
+PlaceholderReadability::PlaceholderReadability() = default;
+
+ReadabilityResult *PlaceholderReadability::fetch(const QUrl &url)
+{
+    auto *result = new ReadabilityResult;
+    QMetaObject::invokeMethod(
+        result,
+        [result] {
+            emit result->error();
+            result->deleteLater();
+        },
+        Qt::QueuedConnection);
+    return result;
+}
+
+} // namespace FeedCore

--- a/feedcore/readability/placeholderreadability.h
+++ b/feedcore/readability/placeholderreadability.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "readability.h"
+
+namespace FeedCore
+{
+
+class PlaceholderReadability : public FeedCore::Readability
+{
+public:
+    PlaceholderReadability();
+    ReadabilityResult *fetch(const QUrl &url) override;
+};
+
+} // namespace FeedCore


### PR DESCRIPTION
Introduce the WITHOUT_QREADABLE build option to build feedcore without a dependency on QReadable. When built in this manner, attempts to fetch readable content will immediately fail.

This is very much not recommended for builds that will be used by humans, since it renders the readability-related features of the application completely non-functional, but it is sometimes convenient for development and testing purposes.