### PR TITLE
Add fallback icons in feed list

### DIFF
--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -45,9 +45,16 @@ ListView {
         contentItem: RowLayout {
             spacing: Kirigami.Units.smallSpacing
 
-            Delegates.IconTitleSubtitle {
+            Kirigami.Icon {
+                source: iconName.length ? "image://feedicons/"+iconName : "feed-subscribe"
+                placeholder: "feed-subscribe"
+                fallback: "feed-subscribe"
+                implicitWidth: Kirigami.Units.iconSizes.smallMedium
+                implicitHeight: implicitWidth
+            }
+
+            Delegates.TitleSubtitle {
                 Layout.fillWidth: true
-                icon.source: iconName.length ? "image://feedicons/"+iconName : "feed-subscribe"
                 title: feed.name
                 selected: listItem.highlighted
             }


### PR DESCRIPTION
This prevents us from showing a "broken image" icon in the feed list when the feed icon fails to load.