### PR TITLE
More prominently display the source feed for articles

### DIFF
--- a/src/qml/ArticleView.qml
+++ b/src/qml/ArticleView.qml
@@ -16,6 +16,7 @@ ColumnLayout {
     property string text: ""
     property string hoveredLink
     property bool showExpandedByline: false
+    readonly property Feed sourceFeed: article.feed
 
     readonly property string textStyle: "<style>
     * {
@@ -25,6 +26,39 @@ ColumnLayout {
         padding-bottom: 12px;
     }
     </style>"
+
+    RowLayout {
+        visible: root.showExpandedByline
+        Layout.bottomMargin: -root.spacing
+        spacing: Kirigami.Units.largeSpacing
+
+        FeedIcon {
+            feed: sourceFeed
+            size: Kirigami.Units.iconSizes.sizeForLabels
+        }
+
+        Label {
+            text: sourceFeed?.name
+            Layout.preferredHeight: visible ? implicitHeight : 0
+            color: Kirigami.Theme.textColor
+            elide: Text.ElideRight
+            horizontalAlignment: Text.AlignLeft
+            verticalAlignment: Text.AlignVCenter
+            opacity: 0.6
+            MouseArea {
+                id: feedMouse
+                anchors.fill: parent
+                hoverEnabled: !Kirigami.Settings.hasTransientTouchInput
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                   const w = Window.window;
+                   if (w && w.selectFeed) {
+                       w.selectFeed(root.article.feed);
+                   }
+                }
+            }
+        }
+    }
 
     Kirigami.Heading {
         level: 1
@@ -49,9 +83,8 @@ ColumnLayout {
 
     RowLayout {
         Label {
-            property string expandedByline: root.article.author + ", <a href=\"syndic-feed-link:\">" + root.article.feed.name + "</a>"
             Layout.fillWidth: true
-            text: showExpandedByline ? expandedByline : root.article.author
+            text: root.article.author
             elide: Text.ElideRight
             horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignVCenter
@@ -60,13 +93,6 @@ ColumnLayout {
             font {
                 italic: true
                 weight: Font.Light
-            }
-
-            onLinkActivated: (link)=>{
-                const w = Window.window;
-                if (w && w.selectFeed) {
-                    w.selectFeed(root.article.feed);
-                }
             }
         }
 

--- a/src/qml/FeedIcon.qml
+++ b/src/qml/FeedIcon.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.12
+import org.kde.kirigami as Kirigami
+import com.rocksandpaper.syndic
+
+Kirigami.Icon {
+    id: root
+    required property Feed feed
+    property alias size: root.implicitWidth
+    property string iconName: feed.icon.toString()
+    source: iconName.length ? "image://feedicons/"+iconName : "feed-subscribe"
+    placeholder: "feed-subscribe"
+    fallback: "feed-subscribe"
+    implicitWidth: Kirigami.Units.iconSizes.smallMedium
+    implicitHeight: implicitWidth
+}

--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -34,7 +34,6 @@ ListView {
         id: listItem
         required property int index
         required property var feed
-        property string iconName: feed.icon.toString()
         property int status: feed.status
         property int unreadCount: feed.unreadCount
         padding: Kirigami.Units.largeSpacing
@@ -45,12 +44,8 @@ ListView {
         contentItem: RowLayout {
             spacing: Kirigami.Units.smallSpacing
 
-            Kirigami.Icon {
-                source: iconName.length ? "image://feedicons/"+iconName : "feed-subscribe"
-                placeholder: "feed-subscribe"
-                fallback: "feed-subscribe"
-                implicitWidth: Kirigami.Units.iconSizes.smallMedium
-                implicitHeight: implicitWidth
+            FeedIcon {
+                feed: listItem.feed
             }
 
             Delegates.TitleSubtitle {

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -24,5 +24,6 @@
         <file>qml/ElasticComboBox.qml</file>
         <file>qml/+org.kde.desktop/ElasticComboBox.qml</file>
         <file>qml/ArticlePageSwipeViewItem.qml</file>
+        <file>qml/FeedIcon.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
We previously appended a link to the source feed at the end of the byline, but that could often be hidden if the byline was long or the window was narrow.

This redesigns the article view a bit so that the source feed is displayed with its icon above the title.

Fixes #155