### PR TITLE
Port away from Kirigami.AbstractArticleListItem

### DIFF
--- a/src/qml/ArticleList/AbstractArticleListPage.qml
+++ b/src/qml/ArticleList/AbstractArticleListPage.qml
@@ -111,9 +111,6 @@ Kirigami.ScrollablePage {
             text: ref.article.headline
             padding: 10
             horizontalPadding: padding * 2
-            implicitWidth: implicitContentWidth + leftPadding + rightPadding
-            implicitHeight:  implicitContentHeight + topPadding + bottomPadding
-            height: implicitHeight
             opacity: enabled ? 1 : 0.6
             highlighted: ListView.isCurrentItem
 

--- a/src/qml/ArticleList/AbstractArticleListPage.qml
+++ b/src/qml/ArticleList/AbstractArticleListPage.qml
@@ -4,6 +4,7 @@
  */
 
 import QtQuick 2.12
+import QtQuick.Controls
 import QtQuick.Layouts 1.12
 import QtQuick.Window 2.15
 import org.kde.kirigami 2.7 as Kirigami
@@ -102,23 +103,26 @@ Kirigami.ScrollablePage {
            }
        } /* model */
 
-        delegate: Kirigami.AbstractListItem {
+        delegate: ItemDelegate {
             id: articleListItem
             required property var ref
             required property int index // needed by Kirigami
             width: articleList.width
             text: ref.article.headline
             padding: 10
-            separatorVisible: true
-
-            // if we don't override this then AbstractListItem sets the height to 0 when the ListView is hidden,
-            // which causes ListView to instantiate a very large number of delegates.
+            horizontalPadding: padding * 2
+            implicitWidth: implicitContentWidth + leftPadding + rightPadding
+            implicitHeight:  implicitContentHeight + topPadding + bottomPadding
             height: implicitHeight
+            opacity: enabled ? 1 : 0.6
+            highlighted: ListView.isCurrentItem
 
             contentItem: ArticleListEntry {
                 article: ref.article
             }
             onClicked: {
+                ListView.view.currentIndex = index;
+
                 // close the feed editor if necessary
                 // TODO this should really emit a signal on articleListController instead of poking at feed editor internals,
                 // but articleListController doesn't exist until the Qt6 migration stuff lands.

--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -30,12 +30,13 @@ ListView {
         }
     }
 
-    delegate: Kirigami.AbstractListItem {
+    delegate: ItemDelegate {
         id: listItem
         required property int index
         required property var feed
         property int status: feed.status
         property int unreadCount: feed.unreadCount
+        width: parent.width
         padding: Kirigami.Units.largeSpacing
         leftPadding: Kirigami.Units.smallSpacing
         rightPadding: Kirigami.Units.smallSpacing
@@ -84,7 +85,10 @@ ListView {
             }
         }
 
-        onClicked: root.itemClicked()
+        onClicked: {
+            ListView.view.currentIndex = index;
+            root.itemClicked()
+        }
     }/* delegate */
 
     section.property: "category"

--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -36,7 +36,7 @@ ListView {
         required property var feed
         property int status: feed.status
         property int unreadCount: feed.unreadCount
-        width: parent.width
+        width: root.width
         padding: Kirigami.Units.largeSpacing
         leftPadding: Kirigami.Units.smallSpacing
         rightPadding: Kirigami.Units.smallSpacing


### PR DESCRIPTION
AbstractListItem is [deprecated upstream](https://invent.kde.org/frameworks/kirigami/-/merge_requests/1358).

This ports our AbstractListItem-based components to ItemDelegate, and copies the bindings that we were depending on in AbstractListItem directly into those components.

*Do not merge this unless AbstractListItem actually gets removed upstream.* We should continue to rely on the framework to provide consistent behavior across applications as long as that continues to be possible.