### PR TITLE
Draft: Overview page showing recommended items from across all feeds

### DIFF
--- a/feedcore/context.cpp
+++ b/feedcore/context.cpp
@@ -186,6 +186,11 @@ QFuture<ArticleRef> Context::getStarred()
     return d->storage->getStarred();
 }
 
+QFuture<ArticleRef> Context::getHighlights()
+{
+    return d->storage->getHighlights();
+}
+
 void Context::requestUpdate()
 {
     const auto &timestamp = QDateTime::currentDateTime();

--- a/feedcore/context.h
+++ b/feedcore/context.h
@@ -148,6 +148,14 @@ public:
     QFuture<ArticleRef> getStarred();
 
     /**
+     * List articles that may be of interest to the user.
+     *
+     * The specific algorithm is determined by the storage
+     * backend.
+     */
+    QFuture<ArticleRef> getHighlights();
+
+    /**
      * Trigger an update on every feed in this context.
      *
      * The updates may not succeed and this method does not provide

--- a/feedcore/storage.h
+++ b/feedcore/storage.h
@@ -24,6 +24,7 @@ public:
     virtual QFuture<ArticleRef> getUnread() = 0;
     virtual QFuture<ArticleRef> getStarred() = 0;
     virtual QFuture<ArticleRef> getSearchResults(const QString &search) = 0;
+    virtual QFuture<ArticleRef> getHighlights() = 0;
     virtual QFuture<Feed *> getFeeds() = 0;
     virtual QFuture<Feed *> storeFeed(Feed *feed) = 0;
 };

--- a/sqlite/feeddatabase.cpp
+++ b/sqlite/feeddatabase.cpp
@@ -168,6 +168,24 @@ ItemQuery FeedDatabase::selectItemsBySearch(const QString &search)
     return q;
 }
 
+ItemQuery FeedDatabase::selectItemsByRecommended(int limit)
+{
+    ItemQuery q(db());
+    q.prepare(
+                "SELECT "+
+                    ItemQuery::fieldList() + ", "
+                    "RANK() over (PARTITION BY feed ORDER BY date DESC) AS feedRank "
+                "FROM Item "
+                "ORDER BY isRead ASC, feedRank ASC, date ASC "
+                "LIMIT :limit;"
+                );
+    q.bindValue(":limit", limit);
+    if (!q.exec()) {
+        qWarning() << "SQL Error in selectItemsByRecommended: " + q.lastError().text();
+    }
+    return q;
+}
+
 ItemQuery FeedDatabase::selectItemsByFeed(qint64 feedId)
 {
     ItemQuery q(db(), "feed=:feed " + select_sort);

--- a/sqlite/feeddatabase.h
+++ b/sqlite/feeddatabase.h
@@ -24,6 +24,8 @@ public:
     ItemQuery selectUnreadItems();
     ItemQuery selectStarredItems();
     ItemQuery selectItemsBySearch(const QString &search);
+    static constexpr const int kDefaultNumberOfRecommendedItems = 10;
+    ItemQuery selectItemsByRecommended(int limit = kDefaultNumberOfRecommendedItems);
     ItemQuery selectItemsByFeed(qint64 feedId);
     ItemQuery selectUnreadItemsByFeed(qint64 feedId);
     ItemQuery selectItem(qint64 id);

--- a/sqlite/itemquery.h
+++ b/sqlite/itemquery.h
@@ -14,13 +14,20 @@ namespace SqliteStorage
 class ItemQuery : public QSqlQuery
 {
 public:
-    ItemQuery(const QSqlDatabase &db, const QString &whereClause)
+    static inline QString fieldList()
+    {
+        return "id, feed, localId, headline, author, date, url, isRead, isStarred";
+    }
+
+    explicit ItemQuery(const QSqlDatabase &db)
         : QSqlQuery(db)
     {
-        prepare(
-            "SELECT id, feed, localId, headline, author, date, url, isRead, isStarred "
-            "FROM Item WHERE "
-            + whereClause);
+    }
+
+    ItemQuery(const QSqlDatabase &db, const QString &whereClause)
+        : ItemQuery(db)
+    {
+        prepare("SELECT " + fieldList() + " FROM Item WHERE " + whereClause);
     }
 
     qint64 id() const

--- a/sqlite/storageimpl.cpp
+++ b/sqlite/storageimpl.cpp
@@ -80,6 +80,14 @@ QFuture<ArticleRef> StorageImpl::getSearchResults(const QString &search)
     });
 }
 
+QFuture<ArticleRef> StorageImpl::getHighlights()
+{
+    return Future::yield<ArticleRef>(this, [this](auto &op) {
+        ItemQuery q{m_db.selectItemsByRecommended()};
+        appendArticleResults(op, q);
+    });
+}
+
 StorageImpl::StorageImpl(const QString &filePath)
     : m_db(filePath)
 {

--- a/sqlite/storageimpl.h
+++ b/sqlite/storageimpl.h
@@ -33,6 +33,7 @@ public:
     QFuture<FeedCore::ArticleRef> getUnread() final;
     QFuture<FeedCore::ArticleRef> getStarred() final;
     QFuture<FeedCore::ArticleRef> getSearchResults(const QString &search) override;
+    QFuture<FeedCore::ArticleRef> getHighlights() final;
     QFuture<FeedCore::Feed *> getFeeds() final;
     QFuture<FeedCore::Feed *> storeFeed(FeedCore::Feed *feed) final;
     void listenForChanges(FeedImpl *feed);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(syndic_HEADERS
     contentimageitem.h
     application.h
     feedmodel.h
+    overviewmodel.h
     networkaccessmanagerfactory.h
     )
 
@@ -30,6 +31,7 @@ set(syndic_SRCS
     networkaccessmanagerfactory.cpp
     application.cpp
     feedmodel.cpp
+    overviewmodel.cpp
     main.cpp
     resources.qrc
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ set(syndic_HEADERS
     contentimageitem.h
     application.h
     feedmodel.h
-    overviewmodel.h
+    highlightsmodel.h
     networkaccessmanagerfactory.h
     )
 
@@ -31,7 +31,7 @@ set(syndic_SRCS
     networkaccessmanagerfactory.cpp
     application.cpp
     feedmodel.cpp
-    overviewmodel.cpp
+    highlightsmodel.cpp
     main.cpp
     resources.qrc
     )

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -25,6 +25,7 @@
 #include "iconprovider.h"
 #include "networkaccessmanagerfactory.h"
 #include "notificationcontroller.h"
+#include "overviewmodel.h"
 #include "platformhelper.h"
 #include "provisionalfeed.h"
 #include "qmlarticleref.h"
@@ -68,6 +69,7 @@ static void registerQmlTypes()
     qmlRegisterType<ContentModel>("com.rocksandpaper.syndic", 1, 0, "ContentModel");
     qmlRegisterType<ContentImageItem>("com.rocksandpaper.syndic", 1, 0, "ContentImage");
     qmlRegisterType<FeedCore::SearchResultFeed>("com.rocksandpaper.syndic", 1, 0, "SearchResultFeed");
+    qmlRegisterType<OverviewModel>("com.rocksandpaper.syndic", 1, 0, "OverviewModel");
     qmlRegisterUncreatableType<FeedCore::Feed::Updater>("com.rocksandpaper.syndic", 1, 0, "Updater", "abstract base class");
     qmlRegisterUncreatableType<FeedCore::Context>("com.rocksandpaper.syndic", 1, 0, "FeedContext", "global object");
     qmlRegisterUncreatableType<FeedCore::Feed>("com.rocksandpaper.syndic", 1, 0, "Feed", "obtained from cpp model");

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -22,10 +22,10 @@
 #include "context.h"
 #include "feedlistmodel.h"
 #include "feedmodel.h"
+#include "highlightsmodel.h"
 #include "iconprovider.h"
 #include "networkaccessmanagerfactory.h"
 #include "notificationcontroller.h"
-#include "overviewmodel.h"
 #include "platformhelper.h"
 #include "provisionalfeed.h"
 #include "qmlarticleref.h"
@@ -69,7 +69,7 @@ static void registerQmlTypes()
     qmlRegisterType<ContentModel>("com.rocksandpaper.syndic", 1, 0, "ContentModel");
     qmlRegisterType<ContentImageItem>("com.rocksandpaper.syndic", 1, 0, "ContentImage");
     qmlRegisterType<FeedCore::SearchResultFeed>("com.rocksandpaper.syndic", 1, 0, "SearchResultFeed");
-    qmlRegisterType<OverviewModel>("com.rocksandpaper.syndic", 1, 0, "OverviewModel");
+    qmlRegisterType<HighlightsModel>("com.rocksandpaper.syndic", 1, 0, "HighlightsModel");
     qmlRegisterUncreatableType<FeedCore::Feed::Updater>("com.rocksandpaper.syndic", 1, 0, "Updater", "abstract base class");
     qmlRegisterUncreatableType<FeedCore::Context>("com.rocksandpaper.syndic", 1, 0, "FeedContext", "global object");
     qmlRegisterUncreatableType<FeedCore::Feed>("com.rocksandpaper.syndic", 1, 0, "Feed", "obtained from cpp model");

--- a/src/articlelistmodel.h
+++ b/src/articlelistmodel.h
@@ -106,6 +106,9 @@ protected:
      */
     virtual void setStatusFromUpstream();
 
+    typedef bool (*ArticleComparator)(const FeedCore::ArticleRef &, const FeedCore::ArticleRef &);
+    virtual ArticleComparator getArticleComparator();
+
     /**
      * Returns true if the source has been initialized
      */
@@ -141,5 +144,6 @@ private:
     void onRefreshFinished(const QList<FeedCore::ArticleRef> &result);
     void onMergeFinished(const QList<FeedCore::ArticleRef> &result);
     void onStatusChanged();
+    int indexForItem(const FeedCore::ArticleRef &item);
     class RowRemoveHelper;
 };

--- a/src/feedmodel.cpp
+++ b/src/feedmodel.cpp
@@ -1,4 +1,5 @@
 #include "feedmodel.h"
+#include "article.h"
 
 using namespace FeedCore;
 
@@ -56,6 +57,16 @@ void FeedModel::setStatusFromUpstream()
     if (feed != nullptr) {
         setStatus(feed->status());
     }
+}
+
+static bool compareDatesDescending(const ArticleRef &l, const ArticleRef &r)
+{
+    return l->date() > r->date();
+}
+
+ArticleListModel::ArticleComparator FeedModel::getArticleComparator()
+{
+    return &compareDatesDescending;
 }
 
 void FeedModel::requestUpdate()

--- a/src/feedmodel.h
+++ b/src/feedmodel.h
@@ -26,6 +26,7 @@ protected:
     void init() override;
     QFuture<FeedCore::ArticleRef> getArticles() override;
     void setStatusFromUpstream() override;
+    ArticleComparator getArticleComparator() override;
 
 private:
     struct PrivData;

--- a/src/highlightsmodel.cpp
+++ b/src/highlightsmodel.cpp
@@ -1,19 +1,19 @@
-#include "overviewmodel.h"
+#include "highlightsmodel.h"
 #include "context.h"
 
 using namespace FeedCore;
 
-OverviewModel::OverviewModel(QObject *parent)
+HighlightsModel::HighlightsModel(QObject *parent)
     : ArticleListModel{parent}
 {
 }
 
-Context *OverviewModel::context() const
+Context *HighlightsModel::context() const
 {
     return m_context;
 }
 
-void OverviewModel::context(Context *newContext)
+void HighlightsModel::context(Context *newContext)
 {
     if (m_context == newContext)
         return;
@@ -21,14 +21,14 @@ void OverviewModel::context(Context *newContext)
     emit contextChanged();
 }
 
-QFuture<ArticleRef> OverviewModel::getArticles()
+QFuture<ArticleRef> HighlightsModel::getArticles()
 {
     if (!m_context)
         return QFuture<ArticleRef>{};
     return m_context->getHighlights();
 }
 
-void OverviewModel::requestUpdate()
+void HighlightsModel::requestUpdate()
 {
     refresh();
 }

--- a/src/highlightsmodel.h
+++ b/src/highlightsmodel.h
@@ -7,25 +7,22 @@ namespace FeedCore
 class Context;
 }
 
-class OverviewModel : public ArticleListModel
+class HighlightsModel : public ArticleListModel
 {
     Q_OBJECT
     Q_PROPERTY(FeedCore::Context *context READ context WRITE context NOTIFY contextChanged)
 public:
-    explicit OverviewModel(QObject *parent = nullptr);
+    explicit HighlightsModel(QObject *parent = nullptr);
     FeedCore::Context *context() const;
     void context(FeedCore::Context *newContext);
+    void requestUpdate() override;
+
 signals:
     void contextChanged();
 
-private:
-    FeedCore::Context *m_context = nullptr;
-
-    // ArticleListModel interface
 protected:
     QFuture<FeedCore::ArticleRef> getArticles() override;
 
-    // ArticleListModel interface
-public:
-    void requestUpdate() override;
+private:
+    FeedCore::Context *m_context = nullptr;
 };

--- a/src/overviewmodel.cpp
+++ b/src/overviewmodel.cpp
@@ -1,0 +1,34 @@
+#include "overviewmodel.h"
+#include "context.h"
+
+using namespace FeedCore;
+
+OverviewModel::OverviewModel(QObject *parent)
+    : ArticleListModel{parent}
+{
+}
+
+Context *OverviewModel::context() const
+{
+    return m_context;
+}
+
+void OverviewModel::context(Context *newContext)
+{
+    if (m_context == newContext)
+        return;
+    m_context = newContext;
+    emit contextChanged();
+}
+
+QFuture<ArticleRef> OverviewModel::getArticles()
+{
+    if (!m_context)
+        return QFuture<ArticleRef>{};
+    return m_context->getHighlights();
+}
+
+void OverviewModel::requestUpdate()
+{
+    refresh();
+}

--- a/src/overviewmodel.h
+++ b/src/overviewmodel.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "articlelistmodel.h"
+
+namespace FeedCore
+{
+class Context;
+}
+
+class OverviewModel : public ArticleListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(FeedCore::Context *context READ context WRITE context NOTIFY contextChanged)
+public:
+    explicit OverviewModel(QObject *parent = nullptr);
+    FeedCore::Context *context() const;
+    void context(FeedCore::Context *newContext);
+signals:
+    void contextChanged();
+
+private:
+    FeedCore::Context *m_context = nullptr;
+
+    // ArticleListModel interface
+protected:
+    QFuture<FeedCore::ArticleRef> getArticles() override;
+
+    // ArticleListModel interface
+public:
+    void requestUpdate() override;
+};

--- a/src/qml/ArticleList/AbstractArticleListPage.qml
+++ b/src/qml/ArticleList/AbstractArticleListPage.qml
@@ -14,8 +14,10 @@ Kirigami.ScrollablePage {
     id: root
     required property Item pageRow
     required property ArticleListModel model
+    property alias delegate: articleList.delegate
     property alias count: articleList.count
     property alias currentIndex: articleList.currentIndex
+    readonly property ListView view: articleList
     property bool isUpdating: model.status === Feed.Updating
     property bool unreadFilter: true
     property bool automaticOpen: pageRow.defaultColumnWidth * 2 < pageRow.width
@@ -102,33 +104,6 @@ Kirigami.ScrollablePage {
 
         model: root.model
 
-        delegate: ItemDelegate {
-            id: articleListItem
-            required property var ref
-            required property int index // needed by Kirigami
-            width: articleList.width
-            text: ref.article.headline
-            padding: 10
-            horizontalPadding: padding * 2
-            opacity: enabled ? 1 : 0.6
-            highlighted: ListView.isCurrentItem
-
-            contentItem: ArticleListEntry {
-                article: ref.article
-            }
-            onClicked: {
-                ListView.view.currentIndex = index;
-
-                // close the feed editor if necessary
-                // TODO this should really emit a signal on articleListController instead of poking at  editor internals,
-                // but articleListController doesn't exist until the Qt6 migration stuff lands.
-                if (pageRow.lastItem.onDone) {
-                    pageRow.lastItem.onDone();
-                }
-                pageRow.currentIndex = root.Kirigami.ColumnView.index + 1
-            }
-        } /*  delegate */
-
         header: Kirigami.InlineMessage {
             id: errorMessage
             text: qsTr("Couldn't fetch feed from source")
@@ -175,5 +150,17 @@ Kirigami.ScrollablePage {
         root.currentIndex = -1
         root.model.removeRead()
         articleList.positionViewAtBeginning()
+    }
+
+    function selectIndex(index) {
+        articleList.currentIndex = index;
+
+        // close the feed editor if necessary
+        // TODO this should really emit a signal on articleListController instead of poking at  editor internals,
+        // but articleListController doesn't exist until the Qt6 migration stuff lands.
+        if (pageRow.lastItem.onDone) {
+            pageRow.lastItem.onDone();
+        }
+        pageRow.currentIndex = root.Kirigami.ColumnView.index + 1
     }
 }

--- a/src/qml/ArticleList/AbstractFeedPage.qml
+++ b/src/qml/ArticleList/AbstractFeedPage.qml
@@ -1,7 +1,9 @@
-import QtQuick 2.12
+import QtQuick
+import QtQuick.Controls
 import com.rocksandpaper.syndic
 
 AbstractArticleListPage {
+    id: root
     required property Feed feed
 
     model: FeedModel {
@@ -9,4 +11,23 @@ AbstractArticleListPage {
         feed: root.feed
         unreadFilter: root.unreadFilter
     }
+
+    delegate: ItemDelegate {
+        id: articleListItem
+        required property var ref
+        required property int index // needed by Kirigami
+        width: ListView.view?.width ?? implicitWidth
+        text: ref.article.headline
+        padding: 10
+        horizontalPadding: padding * 2
+        opacity: enabled ? 1 : 0.6
+        highlighted: ListView.isCurrentItem
+
+        contentItem: ArticleListEntry {
+            article: ref.article
+        }
+        onClicked: {
+            root.selectIndex(index)
+        }
+    } /*  delegate */
 }

--- a/src/qml/ArticleList/OverviewPage.qml
+++ b/src/qml/ArticleList/OverviewPage.qml
@@ -8,7 +8,7 @@ import ".."
 AbstractArticleListPage {
     id: root
     title: qsTr("Highlights")
-    model: OverviewModel {
+    model: HighlightsModel {
         context: feedContext
     }
 

--- a/src/qml/ArticleList/OverviewPage.qml
+++ b/src/qml/ArticleList/OverviewPage.qml
@@ -78,7 +78,6 @@ AbstractArticleListPage {
     Binding {
         root.view.spacing: Kirigami.Units.largeSpacing * 2
         root.view.topMargin: root.view.spacing
-        root.view.bottomMargin: 1000
         root.view.rightMargin: Kirigami.Units.largeSpacing * 2
         root.view.leftMargin: Kirigami.Units.largeSpacing * 2
     }

--- a/src/qml/ArticleList/OverviewPage.qml
+++ b/src/qml/ArticleList/OverviewPage.qml
@@ -1,0 +1,85 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import com.rocksandpaper.syndic
+import org.kde.kirigami as Kirigami
+import ".."
+
+AbstractArticleListPage {
+    id: root
+    title: qsTr("Highlights")
+    model: OverviewModel {
+        context: feedContext
+    }
+
+    delegate: Kirigami.AbstractCard {
+        id: itemCard
+        required property var ref
+        required property int index
+        property Article article: ref.article
+        visible: false
+        highlighted: ListView.isCurrentItem
+        showClickFeedback: true
+        contentItem: ColumnLayout {
+            RowLayout {
+                FeedIcon {
+                    feed: article.feed
+                }
+
+                Label {
+                    text: article.feed.name
+                    elide: Text.ElideRight
+                }
+            }
+
+            Kirigami.Heading {
+                text: article.title
+                textFormat: Text.StyledText
+                wrapMode: Text.Wrap
+                Layout.maximumWidth: parent.width
+            }
+
+            Label {
+                id: contentLabel
+                wrapMode: Text.Wrap
+                elide: Text.ElideRight
+                textFormat: Text.PlainText
+                maximumLineCount: 3
+                Layout.maximumWidth: parent.width
+            }
+        }
+
+        Binding {
+            itemCard.background.opacity: article.isRead && !highlighted ? 0.5 : 1
+        }
+
+        Connections {
+            target: article
+            function onGotContent(content, type) {
+                if (type !== Article.FeedContent) {
+                    return;
+                }
+
+                // TODO replace this with a proper HTML parse
+                contentLabel.text = content.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+                itemCard.visible = true
+            }
+        }
+
+        onClicked: {
+            root.selectIndex(index)
+        }
+
+        Component.onCompleted: {
+            article.requestContent()
+        }
+    }
+
+    Binding {
+        root.view.spacing: Kirigami.Units.largeSpacing * 2
+        root.view.topMargin: root.view.spacing
+        root.view.bottomMargin: 1000
+        root.view.rightMargin: Kirigami.Units.largeSpacing * 2
+        root.view.leftMargin: Kirigami.Units.largeSpacing * 2
+    }
+}

--- a/src/qml/ArticleList/OverviewPage.qml
+++ b/src/qml/ArticleList/OverviewPage.qml
@@ -75,6 +75,16 @@ AbstractArticleListPage {
         }
     }
 
+    actions: [
+        Kirigami.Action {
+            text: qsTr("Refresh")
+            icon.name: "view-refresh"
+            onTriggered: {
+                root.model.requestUpdate();
+            }
+        }
+    ]
+
     Binding {
         root.view.spacing: Kirigami.Units.largeSpacing * 2
         root.view.topMargin: root.view.spacing

--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -15,7 +15,7 @@ ListView {
     property Feed currentlySelectedFeed
     signal itemClicked
 
-    currentIndex: 0
+    currentIndex: -1
     clip: true
     pressDelay: Kirigami.Settings.hasTransientTouchInput ? 120 : 0
     highlightMoveDuration: Kirigami.Units.longDuration

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -115,6 +115,18 @@ Kirigami.ScrollablePage {
         }
 
         ElasticComboBox {
+            id: startPage
+            Kirigami.FormData.label: qsTr("Start page:");
+            model: [qsTr("Highlights"), qsTr("All Items")];
+            currentIndex:  globalSettings.startPage
+            Binding {
+                target: globalSettings
+                property: "startPage"
+                value: startPage.currentIndex
+            }
+        }
+
+        ElasticComboBox {
             id: feedListSort
             Kirigami.FormData.label: qsTr("Sort feed list:");
             model: [qsTr("Alphabetical"), qsTr("Unread First")]

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -109,6 +109,14 @@ Kirigami.ApplicationWindow {
 
         actions: [
             Kirigami.Action {
+                text: qsTr("Highlights")
+                icon.name: "go-home-symbolic"
+                onTriggered: {
+                    priv.pushUtilityPage("qrc:/qml/ArticleList/OverviewPage.qml", {pageRow: pageStack})
+                }
+            },
+
+            Kirigami.Action {
                 text: qsTr("Add Content")
                 icon.name: "list-add"
                 onTriggered: {

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -109,6 +109,7 @@ Kirigami.ApplicationWindow {
 
         actions: [
             Kirigami.Action {
+                id: highlightsAction
                 text: qsTr("Highlights")
                 icon.name: "go-home-symbolic"
                 onTriggered: {
@@ -246,6 +247,18 @@ Kirigami.ApplicationWindow {
     }
 
     Component.onCompleted: {
+        switch (globalSettings.startPage) {
+        default:
+        case 0:
+            highlightsAction.trigger();
+            break;
+
+        case 1:
+            feedList.currentIndex = 0;
+            break;
+        }
+
+
         // HACK workaround Kirigami's hopelessly broken back button behavior
         // Kirigami doesn't accept the underlying key event when the backRequested
         // event is accepted, so if we don't handle the back button directly we

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -27,5 +27,6 @@
         <file>qml/FeedIcon.qml</file>
         <file>qml/ArticleList/SearchResultPage.qml</file>
         <file>qml/ArticleList/AbstractFeedPage.qml</file>
+        <file>qml/ArticleList/OverviewPage.qml</file>
     </qresource>
 </RCC>

--- a/src/settings.kcfg
+++ b/src/settings.kcfg
@@ -60,5 +60,12 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <entry name="columnCount" type="Int">
             <default>0</default>
         </entry>
+        <entry name="startPage" type="Enum">
+            <choices>
+                <choice name="Highlights" />
+                <choice name="AllArticles" />
+            </choices>
+            <default>Highlights</default>
+        </entry>
     </group>
 </kcfg>

--- a/test/mockstorage.h
+++ b/test/mockstorage.h
@@ -77,4 +77,9 @@ public:
             }
         });
     }
+
+    QFuture<FeedCore::ArticleRef> getHighlights() override
+    {
+        return getAll();
+    }
 };

--- a/test/tst_testcontextvaluepropagation.cpp
+++ b/test/tst_testcontextvaluepropagation.cpp
@@ -50,6 +50,11 @@ public:
     {
         return Future::yield<ArticleRef>(this, [](auto &) {});
     }
+
+    QFuture<ArticleRef> getHighlights() override
+    {
+        return Future::yield<ArticleRef>(this, [](auto &) {});
+    }
 };
 
 constexpr const int contextUpdateInterval = 1904;


### PR DESCRIPTION
#179 

Remaining to do:

- [x] Use sort order from the database query; don't force sort by date in the model
- [x] Option to open the home page instead of all items by default (enabled by default)
- [x] Missing bottom margin on the list view
- [x] Button to refresh the view
- [ ] Images when available?
- [ ] Possible fetchMore support?