### PR TITLE
Change padding for feed list items

### DIFF
--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -37,9 +37,7 @@ ListView {
         property int status: feed.status
         property int unreadCount: feed.unreadCount
         width: root.width
-        padding: Kirigami.Units.largeSpacing
-        leftPadding: Kirigami.Units.smallSpacing
-        rightPadding: Kirigami.Units.smallSpacing
+        verticalPadding: Kirigami.Units.largeSpacing
         highlighted: ListView.isCurrentItem
 
         contentItem: RowLayout {


### PR DESCRIPTION
We now inherit the default left/right padding instead of forcing smallSpacing. This accommodates the new qqc2-desktop-style ItemDelegate highlights.

Fixes #204