### PR TITLE
Automatically fetch more recommended items as the existing ones are read

### DIFF
--- a/feedcore/context.cpp
+++ b/feedcore/context.cpp
@@ -188,9 +188,9 @@ QFuture<ArticleRef> Context::getStarred()
     return d->storage->getStarred();
 }
 
-QFuture<ArticleRef> Context::getHighlights()
+QFuture<ArticleRef> Context::getHighlights(size_t limit)
 {
-    return d->storage->getHighlights();
+    return d->storage->getHighlights(limit);
 }
 
 void Context::requestUpdate()

--- a/feedcore/context.h
+++ b/feedcore/context.h
@@ -162,13 +162,15 @@ public:
      */
     QFuture<ArticleRef> getStarred();
 
+    static constexpr const int kDefaultNumberOfRecommendedItems = 20;
+
     /**
      * List articles that may be of interest to the user.
      *
      * The specific algorithm is determined by the storage
      * backend.
      */
-    QFuture<ArticleRef> getHighlights();
+    QFuture<ArticleRef> getHighlights(size_t limit = kDefaultNumberOfRecommendedItems);
 
     /**
      * Trigger an update on every feed in this context.

--- a/feedcore/storage.h
+++ b/feedcore/storage.h
@@ -24,7 +24,7 @@ public:
     virtual QFuture<ArticleRef> getUnread() = 0;
     virtual QFuture<ArticleRef> getStarred() = 0;
     virtual QFuture<ArticleRef> getSearchResults(const QString &search) = 0;
-    virtual QFuture<ArticleRef> getHighlights() = 0;
+    virtual QFuture<ArticleRef> getHighlights(size_t limit) = 0;
     virtual QFuture<Feed *> getFeeds() = 0;
     virtual QFuture<Feed *> storeFeed(Feed *feed) = 0;
 };

--- a/sqlite/feeddatabase.h
+++ b/sqlite/feeddatabase.h
@@ -24,8 +24,7 @@ public:
     ItemQuery selectUnreadItems();
     ItemQuery selectStarredItems();
     ItemQuery selectItemsBySearch(const QString &search);
-    static constexpr const int kDefaultNumberOfRecommendedItems = 20;
-    ItemQuery selectItemsByRecommended(int limit = kDefaultNumberOfRecommendedItems);
+    ItemQuery selectItemsByRecommended(int limit);
     ItemQuery selectItemsByFeed(qint64 feedId);
     ItemQuery selectUnreadItemsByFeed(qint64 feedId);
     ItemQuery selectItem(qint64 id);

--- a/sqlite/storageimpl.cpp
+++ b/sqlite/storageimpl.cpp
@@ -151,10 +151,10 @@ QFuture<ArticleRef> StorageImpl::getSearchResults(const QString &search)
     });
 }
 
-QFuture<ArticleRef> StorageImpl::getHighlights()
+QFuture<ArticleRef> StorageImpl::getHighlights(size_t limit)
 {
-    return m_worker->runInDatabaseThread<ArticleRef>([this](auto &db, auto &op) {
-        ItemQuery q{db.selectItemsByRecommended()};
+    return m_worker->runInDatabaseThread<ArticleRef>([this, limit](auto &db, auto &op) {
+        ItemQuery q{db.selectItemsByRecommended(limit)};
         m_worker->appendArticleResults(op, q);
     });
 }

--- a/sqlite/storageimpl.h
+++ b/sqlite/storageimpl.h
@@ -33,7 +33,7 @@ public:
     QFuture<FeedCore::ArticleRef> getUnread() final;
     QFuture<FeedCore::ArticleRef> getStarred() final;
     QFuture<FeedCore::ArticleRef> getSearchResults(const QString &search) override;
-    QFuture<FeedCore::ArticleRef> getHighlights() final;
+    QFuture<FeedCore::ArticleRef> getHighlights(size_t limit) final;
     QFuture<FeedCore::Feed *> getFeeds() final;
     QFuture<FeedCore::Feed *> storeFeed(FeedCore::Feed *feed) final;
     void listenForChanges(FeedImpl *feed);

--- a/src/articlelistmodel.cpp
+++ b/src/articlelistmodel.cpp
@@ -104,7 +104,7 @@ void ArticleListModel::setUnreadFilter(bool unreadFilter)
     }
 }
 
-LoadStatus ArticleListModel::status()
+LoadStatus ArticleListModel::status() const
 {
     return d->status;
 }

--- a/src/articlelistmodel.h
+++ b/src/articlelistmodel.h
@@ -73,7 +73,7 @@ public:
 
     bool unreadFilter() const;
     void setUnreadFilter(bool unreadFilter);
-    FeedCore::LoadStatus status();
+    FeedCore::LoadStatus status() const;
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const final;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const final;
@@ -133,6 +133,8 @@ protected:
 
     void setStatus(FeedCore::LoadStatus status);
 
+    void refreshMerge();
+
 private:
     struct PrivData;
     std::unique_ptr<PrivData> d;
@@ -140,7 +142,6 @@ private:
     template<typename Callback>
     void getItems(Callback cb);
     void insertAndNotify(int index, const FeedCore::ArticleRef &item);
-    void refreshMerge();
     void onRefreshFinished(const QList<FeedCore::ArticleRef> &result);
     void onMergeFinished(const QList<FeedCore::ArticleRef> &result);
     void onStatusChanged();

--- a/src/highlightsmodel.cpp
+++ b/src/highlightsmodel.cpp
@@ -50,3 +50,26 @@ void HighlightsModel::requestUpdate()
 {
     refresh();
 }
+
+void HighlightsModel::fetchMore(const QModelIndex &parent)
+{
+    if (!canFetchMore(parent)) {
+        return;
+    }
+
+    qDebug() << "fetching more";
+    refreshMerge();
+}
+
+bool HighlightsModel::canFetchMore(const QModelIndex &parent) const
+{
+    if (parent.isValid()) {
+        return false;
+    }
+
+    if (status() != Feed::Idle) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/highlightsmodel.h
+++ b/src/highlightsmodel.h
@@ -16,6 +16,8 @@ public:
     FeedCore::Context *context() const;
     void context(FeedCore::Context *newContext);
     void requestUpdate() override;
+    void fetchMore(const QModelIndex &parent) override;
+    bool canFetchMore(const QModelIndex &parent) const override;
 
 signals:
     void contextChanged();

--- a/test/mockstorage.h
+++ b/test/mockstorage.h
@@ -78,7 +78,7 @@ public:
         });
     }
 
-    QFuture<FeedCore::ArticleRef> getHighlights() override
+    QFuture<FeedCore::ArticleRef> getHighlights(size_t limit) override
     {
         return getAll();
     }

--- a/test/tst_testcontextvaluepropagation.cpp
+++ b/test/tst_testcontextvaluepropagation.cpp
@@ -51,7 +51,7 @@ public:
         return Future::yield<ArticleRef>(this, [](auto &) {});
     }
 
-    QFuture<ArticleRef> getHighlights() override
+    QFuture<ArticleRef> getHighlights(size_t limit) override
     {
         return Future::yield<ArticleRef>(this, [](auto &) {});
     }


### PR DESCRIPTION
This ensures that a user who only interacts with the application through the highlights page will eventually see all unread articles. This is important if the highlights page is going to be the default start page going forward, otherwise naive users may end up never seeing some of the articles in their collection.