### PR TITLE
Update flatpak runtime

### DIFF
--- a/com.rocksandpaper.syndic.yml
+++ b/com.rocksandpaper.syndic.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 id: com.rocksandpaper.syndic
 runtime: org.kde.Platform
-runtime-version: '6.6'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 command: syndic
 finish-args:


### PR DESCRIPTION
Use 6.8 runtime instead of EOL 6.6