### PR TITLE
Move web content pre-fetch from updater to automation rule

### DIFF
--- a/feedcore/CMakeLists.txt
+++ b/feedcore/CMakeLists.txt
@@ -26,6 +26,7 @@ set(feedcore_HEADERS
     automation/automationrule.h
     readability/readability.h
     readability/readabilityresult.h
+    readability/readabilityprefetchrule.h
     )
     
 set(feedcore_SRCS
@@ -46,8 +47,10 @@ set(feedcore_SRCS
     gumbovisitor.cpp
     feeddiscovery.cpp
     searchresultfeed.cpp
+    automation/abstractautomationrule.h
     automation/automationengine.cpp
     automation/automationrule.cpp
+    readability/readabilityprefetchrule.cpp
     )
 
 if (QReadable_FOUND)

--- a/feedcore/automation/abstractautomationrule.h
+++ b/feedcore/automation/abstractautomationrule.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "articleref.h"
+#include <QFuture>
+#include <QObject>
+
+namespace FeedCore
+{
+class AbstractAutomationRule : public QObject
+{
+    Q_OBJECT
+public:
+    explicit AbstractAutomationRule(QObject *parent = nullptr)
+        : QObject(parent){};
+    ;
+    virtual bool matches(const ArticleRef &article) = 0;
+    virtual QFuture<void> beginPerformAction(const ArticleRef &article) = 0;
+};
+}

--- a/feedcore/automation/automationengine.cpp
+++ b/feedcore/automation/automationengine.cpp
@@ -13,8 +13,7 @@
 using namespace FeedCore;
 
 AutomationEngine::AutomationEngine(Context *parent)
-    : QObject{parent}
-    , m_monitorFeed{parent->allItemsFeed()}
+    : m_monitorFeed{parent->allItemsFeed()}
 {
     QObject::connect(m_monitorFeed.get(), &Feed::articleAdded, this, &AutomationEngine::processArticle);
 }
@@ -22,25 +21,41 @@ AutomationEngine::AutomationEngine(Context *parent)
 void AutomationEngine::processArticle(const ArticleRef &article)
 {
     for (auto *r : std::as_const(m_rules)) {
-        r->apply(article);
+        if (r->matches(article)) {
+            m_actionQueue.enqueue({r, article});
+        }
     }
+    processPendingActions();
 }
 
-const QList<AutomationRule *> &AutomationEngine::automationRules()
+void AutomationEngine::addAutomationRule(AbstractAutomationRule *rule)
+{
+    if (m_rules.contains(rule)) {
+        return;
+    }
+    rule->setParent(this);
+    m_rules << rule;
+}
+
+const QList<AbstractAutomationRule *> &AutomationEngine::automationRules()
 {
     return m_rules;
 }
 
-AutomationRule *AutomationEngine::addAutomationRule()
+AbstractAutomationRule *AutomationEngine::addAutomationRule()
 {
     auto *rule = new AutomationRule(this);
     m_rules << rule;
     return rule;
 }
 
-bool AutomationEngine::removeAutomationRule(AutomationRule *rule)
+bool AutomationEngine::removeAutomationRule(AbstractAutomationRule *rule)
 {
     if (m_rules.removeOne(rule)) {
+        // If the rule is in the queue, remove it
+        m_actionQueue.removeIf([rule](const PendingAction &op) {
+            return op.rule == rule;
+        });
         delete rule;
         return true;
     };
@@ -51,7 +66,7 @@ AutomationEngine *AutomationEngine::fromDefaultConfigFile(Context *parent)
 {
     constexpr const char *kConfigFileName = "automation.json";
     QString configPath = QStandardPaths::locate(QStandardPaths::AppDataLocation, kConfigFileName);
-    if (configPath.isEmpty()) {
+    if (configPath.isEmpty() || !QFile::exists(configPath)) {
         return nullptr;
     }
 
@@ -63,11 +78,38 @@ AutomationEngine *AutomationEngine::fromDefaultConfigFile(Context *parent)
     return result;
 }
 
+void AutomationEngine::beginNextAction()
+{
+    m_activeActions++;
+    PendingAction op = m_actionQueue.dequeue();
+    auto action = op.rule->beginPerformAction(op.article);
+    Future::safeThen(action, this, [this](auto) {
+        onActionFinished();
+    });
+}
+
+void AutomationEngine::processPendingActions()
+{
+    while (m_activeActions < maxConcurrentActions() && !m_actionQueue.isEmpty()) {
+        beginNextAction();
+    }
+}
+
+void AutomationEngine::onActionFinished()
+{
+    m_activeActions--;
+    processPendingActions();
+}
+
+int AutomationEngine::maxConcurrentActions()
+{
+    return QThread::idealThreadCount();
+}
+
 bool AutomationEngine::loadJson(const QString &path)
 {
     QFile file(path);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qDebug() << "failed to initialize automation: couldn't open config file";
         return false;
     }
     QJsonDocument json = QJsonDocument::fromJson(file.readAll());
@@ -83,5 +125,5 @@ bool AutomationEngine::loadJson(const QString &path)
         m_rules << new AutomationRule(val.toObject(), this);
     }
 
-    return m_rules.length() > 0;
+    return !m_rules.empty();
 }

--- a/feedcore/automation/automationengine.h
+++ b/feedcore/automation/automationengine.h
@@ -4,28 +4,43 @@
  */
 #pragma once
 #include "articleref.h"
+#include <QFuture>
 #include <QObject>
+#include <QQueue>
 
 namespace FeedCore
 {
 class Context;
 class Feed;
-class AutomationRule;
+class AbstractAutomationRule;
 class AutomationEngine : public QObject
 {
     Q_OBJECT
 public:
     explicit AutomationEngine(Context *parent);
     void processArticle(const ArticleRef &article);
-    const QList<FeedCore::AutomationRule *> &automationRules();
-    FeedCore::AutomationRule *addAutomationRule();
-    bool removeAutomationRule(FeedCore::AutomationRule *rule);
+    const QList<FeedCore::AbstractAutomationRule *> &automationRules();
+    FeedCore::AbstractAutomationRule *addAutomationRule();
+    void addAutomationRule(FeedCore::AbstractAutomationRule *rule);
+    bool removeAutomationRule(FeedCore::AbstractAutomationRule *rule);
     static AutomationEngine *fromDefaultConfigFile(Context *parent);
 
 private:
-    QList<AutomationRule *> m_rules;
+    struct PendingAction {
+        AbstractAutomationRule *rule;
+        ArticleRef article;
+    };
+
+    QList<AbstractAutomationRule *> m_rules;
     QSharedPointer<Feed> m_monitorFeed;
+    QQueue<PendingAction> m_actionQueue;
+    int m_activeActions = 0;
+
     bool loadJson(const QString &path);
+    void beginNextAction();
+    void processPendingActions();
+    void onActionFinished();
+    static int maxConcurrentActions();
 };
 
 } // namespace FeedCore

--- a/feedcore/automation/automationrule.h
+++ b/feedcore/automation/automationrule.h
@@ -5,12 +5,14 @@
 #pragma once
 
 #include "articleref.h"
+#include "automation/abstractautomationrule.h"
+#include <QFuture>
 #include <QObject>
 
 namespace FeedCore
 {
 class AutomationEngine;
-class AutomationRule : public QObject
+class AutomationRule : public AbstractAutomationRule
 {
     Q_OBJECT
     Q_PROPERTY(FeedCore::AutomationRule::MatchField matchField READ matchField WRITE setMatchField NOTIFY matchFieldChanged)
@@ -22,8 +24,6 @@ class AutomationRule : public QObject
 public:
     enum MatchField { MatchEverything = 0, MatchFeed, MatchAuthor, MatchTitle };
     Q_ENUM(MatchField);
-
-    void apply(const ArticleRef &article);
 
     FeedCore::AutomationRule::MatchField matchField() const;
     void setMatchField(FeedCore::AutomationRule::MatchField newMatchField);
@@ -69,8 +69,8 @@ private:
 
     explicit AutomationRule(QObject *parent = nullptr);
     explicit AutomationRule(const QJsonObject &obj, QObject *parent);
-    bool matches(const ArticleRef &article);
-    void performAction(const ArticleRef &article);
+    bool matches(const ArticleRef &article) override;
+    QFuture<void> beginPerformAction(const ArticleRef &article) override;
     friend class FeedCore::AutomationEngine;
 };
 }

--- a/feedcore/context.cpp
+++ b/feedcore/context.cpp
@@ -457,6 +457,7 @@ void Context::setPrefetchContent(bool newPrefetchContent)
     } else {
         if (auto &engine = d->automationEngine) {
             engine->removeAutomationRule(d->prefetchContentRule);
+            d->prefetchContentRule = nullptr;
         }
     }
     emit prefetchContentChanged();

--- a/feedcore/context.cpp
+++ b/feedcore/context.cpp
@@ -11,6 +11,7 @@
 #include "future.h"
 #include "opmlreader.h"
 #include "provisionalfeed.h"
+#include "readability/readabilityprefetchrule.h"
 #include "scheduler.h"
 #include "storage.h"
 #include <QDebug>
@@ -43,7 +44,7 @@ private:
 }
 
 struct Context::PrivData {
-    enum ContextFlags { FeedListComplete = 1, UpdateRequestPending = 1U << 1U, PrefetchReadableContent = 1U << 2U, FeedsScheduledByDefault = 1U << 3U };
+    enum ContextFlags { FeedListComplete = 1, UpdateRequestPending = 1U << 1U, FeedsScheduledByDefault = 1U << 2U };
 
     Context *parent;
     Storage *storage;
@@ -52,8 +53,10 @@ struct Context::PrivData {
     qint64 expireAge{0};
     Scheduler *updateScheduler;
     Readability *readability{nullptr};
-    QFlags<ContextFlags> flags{};
+    QFlags<ContextFlags> flags;
     QWeakPointer<AllItemsFeed> allItemsFeed{nullptr};
+    std::unique_ptr<AutomationEngine> automationEngine;
+    QPointer<AbstractAutomationRule> prefetchContentRule{nullptr};
 
     PrivData(Storage *storage, Context *parent);
     void configureUpdates(Feed *feed, const QDateTime &timestamp = QDateTime::currentDateTime()) const;
@@ -73,7 +76,7 @@ Context::Context(Storage *storage, QObject *parent)
     Future::safeThen(getFeeds, this, [this](auto &getFeeds) {
         populateFeeds(Future::safeResults(getFeeds));
     });
-    AutomationEngine::fromDefaultConfigFile(this);
+    d->automationEngine.reset(AutomationEngine::fromDefaultConfigFile(this));
     d->updateScheduler->start();
 }
 
@@ -352,6 +355,14 @@ Readability *Context::getReadability()
     return d->readability;
 }
 
+AutomationEngine *Context::automationEngine()
+{
+    if (d->automationEngine == nullptr) {
+        d->automationEngine = std::make_unique<AutomationEngine>(this);
+    }
+    return d->automationEngine.get();
+}
+
 bool Context::feedListComplete()
 {
     return d->flags.testFlag(PrivData::FeedListComplete);
@@ -430,7 +441,7 @@ void Context::startUpdatesForAllFeeds()
 
 bool Context::prefetchContent() const
 {
-    return d->flags.testFlag(PrivData::PrefetchReadableContent);
+    return d->prefetchContentRule != nullptr;
 }
 
 void Context::setPrefetchContent(bool newPrefetchContent)
@@ -438,7 +449,16 @@ void Context::setPrefetchContent(bool newPrefetchContent)
     if (prefetchContent() == newPrefetchContent) {
         return;
     }
-    d->flags.setFlag(PrivData::PrefetchReadableContent, newPrefetchContent);
+    if (newPrefetchContent) {
+        if (d->prefetchContentRule == nullptr) {
+            d->prefetchContentRule = new ReadabilityPrefetchRule(getReadability(), this);
+            automationEngine()->addAutomationRule(d->prefetchContentRule);
+        }
+    } else {
+        if (auto &engine = d->automationEngine) {
+            engine->removeAutomationRule(d->prefetchContentRule);
+        }
+    }
     emit prefetchContentChanged();
 }
 

--- a/feedcore/context.h
+++ b/feedcore/context.h
@@ -17,6 +17,7 @@ class Storage;
 class Feed;
 class ProvisionalFeed;
 class Readability;
+class AutomationEngine;
 
 class Context;
 
@@ -209,6 +210,8 @@ public:
      * This may be null if we were built without readability support
      */
     Readability *getReadability();
+
+    AutomationEngine *automationEngine();
 
     bool defaultUpdateEnabled() const;
     void setDefaultUpdateEnabled(bool defaultUpdateEnabled);

--- a/feedcore/readability/readabilityprefetchrule.cpp
+++ b/feedcore/readability/readabilityprefetchrule.cpp
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include "readabilityprefetchrule.h"
+#include "article.h"
+#include "feed.h"
+#include "readability.h"
+#include "readabilityresult.h"
+#include <QFlags>
+#include <QPromise>
+
+using namespace FeedCore;
+
+ReadabilityPrefetchRule::ReadabilityPrefetchRule(Readability *readability, QObject *parent)
+    : AbstractAutomationRule(parent)
+    , m_readability(readability)
+{
+}
+
+bool ReadabilityPrefetchRule::matches(const ArticleRef &article)
+{
+    if (!article->feed()) {
+        // feed has been deleted, don't match
+        return false;
+    };
+    // check if we have already fetched the content
+    return QFlags<Feed::FeedFlags>(article->feed()->flags()).testFlag(Feed::UseReadableContentFlag);
+}
+
+QFuture<void> ReadabilityPrefetchRule::beginPerformAction(const ArticleRef &article)
+{
+    // make sure we still match when it's time to run
+    if (!matches(article)) {
+        return QtFuture::makeReadyVoidFuture();
+    }
+
+    auto *promise = new QPromise<void>();
+    promise->start();
+
+    ReadabilityResult *result = m_readability->fetch(article->url());
+
+    QObject::connect(result, &ReadabilityResult::finished, result, [article, promise](const QString &content) {
+        article->cacheReadableContent(content);
+        promise->finish();
+        delete promise;
+    });
+
+    QObject::connect(result, &ReadabilityResult::error, result, [promise, article]() {
+        qDebug() << "Readability content fetch failed for " << article->url();
+        promise->finish();
+        delete promise;
+    });
+
+    return promise->future();
+}

--- a/feedcore/readability/readabilityprefetchrule.h
+++ b/feedcore/readability/readabilityprefetchrule.h
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include "automation/abstractautomationrule.h"
+#include <QObject>
+
+namespace FeedCore
+{
+class Readability;
+class ReadabilityResult;
+
+class ReadabilityPrefetchRule : public AbstractAutomationRule
+{
+    Q_OBJECT
+
+public:
+    explicit ReadabilityPrefetchRule(Readability *readability, QObject *parent = nullptr);
+    bool matches(const ArticleRef &article) override;
+    QFuture<void> beginPerformAction(const ArticleRef &article) override;
+
+private:
+    Readability *m_readability;
+};
+
+} // namespace FeedCore


### PR DESCRIPTION
Moves the existing logic for pre-fetching web page text with readability out of the updater into the automation engine. The update can now finish while web content is still being downloaded in the background.

Since the web content prefetch is simply populating a cache, there is no reason to make the user wait for it to complete before browsing; the worst case scenario is just a cache miss.

This change makes it a bit more urgent that we create a user interface for managing the automation engine and its tasks (issue #189).

Fixes #253