### PR TITLE
Rework settings for downloading web content

### DIFF
--- a/po/syndic.pot
+++ b/po/syndic.pot
@@ -101,7 +101,7 @@ msgctxt "AddFeedPage|"
 msgid "Preview…"
 msgstr ""
 
-#: src/application.cpp:127
+#: src/application.cpp:129
 msgctxt "Application|"
 msgid "Syndic"
 msgstr ""
@@ -219,117 +219,137 @@ msgctxt "OverviewPage|"
 msgid "Refresh"
 msgstr ""
 
+#: src/qml/ReadableContentSettingsDialog.qml:15
+msgctxt "ReadableContentSettingsDialog|"
+msgid "Select feeds to display web content:"
+msgstr ""
+
+#: src/qml/ReadableContentSettingsDialog.qml:57
+msgctxt "ReadableContentSettingsDialog|"
+msgid "Download articles:"
+msgstr ""
+
+#: src/qml/ReadableContentSettingsDialog.qml:64
+msgctxt "ReadableContentSettingsDialog|"
+msgid "When opened"
+msgstr ""
+
+#: src/qml/ReadableContentSettingsDialog.qml:64
+msgctxt "ReadableContentSettingsDialog|"
+msgid "With feed updates"
+msgstr ""
+
 #: src/qml/ArticleList/SearchResultPage.qml:8
 #, qt-format
 msgctxt "SearchResultPage|"
 msgid "Search results for \"%1\""
 msgstr ""
 
-#: src/qml/SettingsPage.qml:16
+#: src/qml/SettingsPage.qml:18
 msgctxt "SettingsPage|"
 msgid "Settings"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:23
+#: src/qml/SettingsPage.qml:25
 msgctxt "SettingsPage|"
 msgid "Fetch updates:"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:25
+#: src/qml/SettingsPage.qml:27
 msgctxt "SettingsPage|"
 msgid "On application start"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:37
+#: src/qml/SettingsPage.qml:39
 msgctxt "SettingsPage|"
 msgid "Automatically every:"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:49
+#: src/qml/SettingsPage.qml:51
 #, qt-format
 msgctxt "SettingsPage|"
 msgid "%n minute(s)"
 msgid_plural "%n minute(s)"
 msgstr[0] ""
 
-#: src/qml/SettingsPage.qml:61
+#: src/qml/SettingsPage.qml:63
 msgctxt "SettingsPage|"
 msgid "Run in background"
 msgstr ""
 
 #: src/qml/SettingsPage.qml:74
 msgctxt "SettingsPage|"
-msgid "Download web content for offline viewing"
-msgstr ""
-
-#: src/qml/SettingsPage.qml:85
-msgctxt "SettingsPage|"
-msgid "Some web servers may not support this feature."
-msgstr ""
-
-#: src/qml/SettingsPage.qml:92
-msgctxt "SettingsPage|"
 msgid "Delete old items:"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:107
+#: src/qml/SettingsPage.qml:89
 #, qt-format
 msgctxt "SettingsPage|"
 msgid "%n day(s)"
 msgid_plural "%n day(s)"
 msgstr[0] ""
 
-#: src/qml/SettingsPage.qml:119
+#: src/qml/SettingsPage.qml:101
 msgctxt "SettingsPage|"
 msgid "Start page:"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:121
+#: src/qml/SettingsPage.qml:103
 msgctxt "SettingsPage|"
 msgid "Highlights"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:121
+#: src/qml/SettingsPage.qml:103
 msgctxt "SettingsPage|"
 msgid "All Items"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:132
+#: src/qml/SettingsPage.qml:114
 msgctxt "SettingsPage|"
 msgid "Sort feed list:"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:134
+#: src/qml/SettingsPage.qml:116
 msgctxt "SettingsPage|"
 msgid "Alphabetical"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:134
+#: src/qml/SettingsPage.qml:116
 msgctxt "SettingsPage|"
 msgid "Unread First"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:145
+#: src/qml/SettingsPage.qml:127
 msgctxt "SettingsPage|"
 msgid "Article font:"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:147
+#: src/qml/SettingsPage.qml:129
 msgctxt "SettingsPage|entry in font list"
 msgid "Use system font"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:165
+#: src/qml/SettingsPage.qml:147
+msgctxt "SettingsPage|"
+msgid "Web content:"
+msgstr ""
+
+#: src/qml/SettingsPage.qml:148
+msgctxt "SettingsPage|"
+msgid "Configure…"
+msgstr ""
+
+#: src/qml/SettingsPage.qml:157
 msgctxt "SettingsPage|"
 msgid "OPML Data:"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:168
+#: src/qml/SettingsPage.qml:159
 msgctxt "SettingsPage|"
 msgid "Import…"
 msgstr ""
 
-#: src/qml/SettingsPage.qml:181
+#: src/qml/SettingsPage.qml:172
 msgctxt "SettingsPage|"
 msgid "Export…"
 msgstr ""

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(syndic_HEADERS
     feedmodel.h
     highlightsmodel.h
     networkaccessmanagerfactory.h
+    editablefeedlistmodel.h
     )
 
 set(syndic_SRCS
@@ -32,6 +33,7 @@ set(syndic_SRCS
     application.cpp
     feedmodel.cpp
     highlightsmodel.cpp
+    editablefeedlistmodel.cpp
     main.cpp
     resources.qrc
     )

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -20,6 +20,7 @@
 #include "contentimageitem.h"
 #include "contentmodel.h"
 #include "context.h"
+#include "editablefeedlistmodel.h"
 #include "feedlistmodel.h"
 #include "feedmodel.h"
 #include "highlightsmodel.h"
@@ -64,6 +65,7 @@ static FeedCore::Context *createContext(QObject *parent = nullptr)
 static void registerQmlTypes()
 {
     qmlRegisterType<FeedListModel>("com.rocksandpaper.syndic", 1, 0, "FeedListModel");
+    qmlRegisterType<EditableFeedListModel>("com.rocksandpaper.syndic", 1, 0, "EditableFeedListModel");
     qmlRegisterType<FeedModel>("com.rocksandpaper.syndic", 1, 0, "FeedModel");
     qmlRegisterType<FeedCore::ProvisionalFeed>("com.rocksandpaper.syndic", 1, 0, "ProvisionalFeed");
     qmlRegisterType<ContentModel>("com.rocksandpaper.syndic", 1, 0, "ContentModel");

--- a/src/editablefeedlistmodel.cpp
+++ b/src/editablefeedlistmodel.cpp
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: 2021 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "editablefeedlistmodel.h"
+#include "feed.h"
+#include "feedlistmodel.h"
+
+EditableFeedListModel::EditableFeedListModel(QObject *parent)
+    : QSortFilterProxyModel(parent)
+{
+    setSortRole(Qt::DisplayRole);
+    setSortCaseSensitivity(Qt::CaseInsensitive);
+    sort(0, Qt::AscendingOrder);
+}
+
+bool EditableFeedListModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+    QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
+    auto *feed = sourceModel()->data(index, FeedListModel::FeedRole).value<FeedCore::Feed *>();
+    return (feed != nullptr) && feed->editable();
+}
+
+bool EditableFeedListModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
+{
+    // sort by feed name
+    auto *leftFeed = sourceModel()->data(left, FeedListModel::FeedRole).value<FeedCore::Feed *>();
+    auto *rightFeed = sourceModel()->data(right, FeedListModel::FeedRole).value<FeedCore::Feed *>();
+
+    if (!leftFeed || !rightFeed) {
+        return false;
+    }
+    return leftFeed->name().localeAwareCompare(rightFeed->name()) < 0;
+}

--- a/src/editablefeedlistmodel.h
+++ b/src/editablefeedlistmodel.h
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2021 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+#include <QSortFilterProxyModel>
+
+/**
+ * Proxy model for the feed list that filters to show only editable feeds and sorts them by name
+ *
+ * Source model is expected to be a FeedListModel
+ */
+class EditableFeedListModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    explicit EditableFeedListModel(QObject *parent = nullptr);
+
+protected:
+    // filter by editable feeds
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+
+    // sort by feed name
+    bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
+};

--- a/src/qml/ReadableContentSettingsDialog.qml
+++ b/src/qml/ReadableContentSettingsDialog.qml
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import org.kde.kirigami 2.12 as Kirigami
+import com.rocksandpaper.syndic 1.0
+
+Kirigami.Dialog {
+    id: root
+    
+    title: qsTr("Select feeds to display web content:")
+    
+    required property var feedListModel
+    
+    width: Math.min(parent.width - Kirigami.Units.largeSpacing * 4, Kirigami.Units.gridUnit * 30)
+    height: Math.min(parent.height - Kirigami.Units.largeSpacing * 4, Kirigami.Units.gridUnit * 30)
+        
+    ListView {
+        id: feedListView
+        model: EditableFeedListModel {
+            sourceModel: root.feedListModel
+        }
+        delegate: CheckDelegate {
+            required property var feed
+            required property int index
+
+            text: feed.name
+
+            // Check if feed's flags include the UseReadableContentFlag
+            checked: feed.flags & Feed.UseReadableContentFlag
+
+            onToggled: {
+                // Toggle the flag using bitwise operations
+                if (checked) {
+                    feed.flags |= Feed.UseReadableContentFlag
+                } else {
+                    feed.flags &= ~Feed.UseReadableContentFlag
+                }
+            }
+
+            width: ListView.view.width
+        }
+    }
+
+    footer: Control {
+        padding: Kirigami.Units.smallSpacing
+
+        contentItem: RowLayout {
+            spacing: Kirigami.Units.smallSpacing
+
+            Label {
+                Layout.alignment: Qt.AlignRight
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignRight
+                text: qsTr("Download articles:")
+            }
+
+            ComboBox {
+                id: prefetchContent
+                Layout.alignment: Qt.AlignRight
+                implicitContentWidthPolicy: ComboBox.WidestTextWhenCompleted
+                model: [qsTr("When opened"), qsTr("With feed updates")]
+                currentIndex: globalSettings.prefetchContent ? 1 : 0
+                Binding {
+                    target: globalSettings
+                    property: "prefetchContent"
+                    value: prefetchContent.currentIndex === 1
+                }
+            }
+        }
+    }
+}

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -8,10 +8,12 @@ import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.0
 import QtQuick.Dialogs
 import org.kde.kirigami 2.7 as Kirigami
+import com.rocksandpaper.syndic 1.0
 
 Kirigami.ScrollablePage {
     id: root
     property bool keepDrawerOpen: true
+    required property FeedListModel feedListModel
 
     title: qsTr("Settings")
 
@@ -65,26 +67,6 @@ Kirigami.ScrollablePage {
                 target: globalSettings
                 property: "runInBackground"
                 value: runInBackground.checked
-            }
-        }
-
-        RowLayout {
-            CheckBox {
-                id: prefetchContent
-                text: qsTr("Download web content for offline viewing")
-                checked: globalSettings.prefetchContent
-                Binding {
-                    target: globalSettings
-                    property: "prefetchContent"
-                    value: prefetchContent.checked
-                }
-            }
-            Button {
-                icon.name: "help-contextual"
-                flat: true
-                ToolTip.text: qsTr("Some web servers may not support this feature.")
-                ToolTip.visible: pressed || hovered
-                ToolTip.delay: pressed ? -1 : Kirigami.Units.toolTipDelay
             }
         }
 
@@ -146,7 +128,7 @@ Kirigami.ScrollablePage {
             implicitContentWidthPolicy: ComboBox.WidestTextWhenCompleted
             model: [qsTr("Use system font", "entry in font list"), "serif", ...Qt.fontFamilies()]
             onActivated: {
-                if (currentIndex == 0) {
+                if (currentIndex === 0) {
                     globalSettings.bodyFont = "";
                 } else {
                     globalSettings.bodyFont = currentText
@@ -160,10 +142,19 @@ Kirigami.ScrollablePage {
                 }
             }
         }
+        
+        Button {
+            Kirigami.FormData.label: qsTr("Web content:")
+            text: qsTr("Configure…")
+            onClicked: {
+                dialogLoader.sourceComponent = readableContentDialogComponent;
+                const dialog = dialogLoader.item;
+                dialog.open();
+            }
+        }
 
         RowLayout {
             Kirigami.FormData.label: qsTr("OPML Data:")
-
             Button {
                 text: qsTr("Import…");
                 onClicked: {
@@ -203,6 +194,14 @@ Kirigami.ScrollablePage {
             FileDialog {
                 property var acceptedFunc: function(){}
                 onAccepted: acceptedFunc();
+            }
+        },
+        
+        Component {
+            id: readableContentDialogComponent;
+            
+            ReadableContentSettingsDialog {
+                feedListModel: root.feedListModel
             }
         }
     ]

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -128,7 +128,7 @@ Kirigami.ApplicationWindow {
                 text: qsTr("Settings")
                 icon.name: "settings-configure"
                 onTriggered: {
-                    priv.pushUtilityPage("qrc:/qml/SettingsPage.qml")
+                    priv.pushUtilityPage("qrc:/qml/SettingsPage.qml", {feedListModel: feedList.model})
                 }
             },
             Kirigami.Action {

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -27,5 +27,6 @@
         <file>qml/ArticleList/AbstractFeedPage.qml</file>
         <file>qml/ArticleList/OverviewPage.qml</file>
         <file>qml/ArticleList/StarredItemsPage.qml</file>
+        <file>qml/ReadableContentSettingsDialog.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION

![web-content-dialog](https://github.com/user-attachments/assets/7ba76e82-532a-4b81-8b1d-4a7759ee4899)
Replaces the checkbox in settings "Download web content for offline viewing" with a new dialog box to select both the specific feeds that use web content *and* the strategy for downloading it. This solves the issue of these two things confusingly being in different places (see #232).