### PR TITLE
Disable hover effects on the article list when using touchscreen

### DIFF
--- a/src/qml/ArticleList/AbstractFeedPage.qml
+++ b/src/qml/ArticleList/AbstractFeedPage.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import org.kde.kirigami as Kirigami
 import com.rocksandpaper.syndic
 
 AbstractArticleListPage {
@@ -23,6 +24,7 @@ AbstractArticleListPage {
         horizontalPadding: padding * 2
         opacity: enabled ? 1 : 0.6
         highlighted: ListView.isCurrentItem
+        hoverEnabled: !Kirigami.Settings.hasTransientTouchInput
 
         contentItem: ArticleListEntry {
             article: ref.article


### PR DESCRIPTION
The "hover" effect that we use for mouse input ends up making arbitrary articles appear highlighted when using touch input. This disables hover effects.

Fixes #236