### PR TITLE
Fall back to scraping links from the web page if a feed can't be found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ include(ECMPoQmTools)
 include(KDEInstallDirs)
 include(KDECMakeSettings)
 
-find_package(Qt6 COMPONENTS Core Qml Network Quick QuickControls2 Sql REQUIRED)
+find_package(Qt6 COMPONENTS Core Qml Network Quick QuickControls2 Sql Xml
+    REQUIRED)
 
 find_package(KF6Syndication REQUIRED)
 find_package(KF6Config REQUIRED)

--- a/feedcore/CMakeLists.txt
+++ b/feedcore/CMakeLists.txt
@@ -22,6 +22,7 @@ set(feedcore_HEADERS
     gumbovisitor.h
     feeddiscovery.h
     searchresultfeed.h
+    articlelinkextractor.h
     automation/automationengine.h
     automation/automationrule.h
     readability/readability.h
@@ -47,6 +48,7 @@ set(feedcore_SRCS
     gumbovisitor.cpp
     feeddiscovery.cpp
     searchresultfeed.cpp
+    articlelinkextractor.cpp
     automation/abstractautomationrule.h
     automation/automationengine.cpp
     automation/automationrule.cpp
@@ -63,13 +65,16 @@ else()
         readability/placeholderreadability.cpp)
 endif()
 
-add_library(feedcore STATIC ${feedcore_SRCS})
+add_library(feedcore STATIC ${feedcore_SRCS}
+    articlelinkextractor.h
+    articlelinkextractor.cpp)
 ecm_create_qm_loader(feedcore feedcore)
 
 target_link_libraries(feedcore
     Qt6::Core
     Qt6::Sql
     Qt6::Network
+    Qt6::Xml
     KF6::Syndication
     htmlparser
 )

--- a/feedcore/articlelinkextractor.cpp
+++ b/feedcore/articlelinkextractor.cpp
@@ -1,0 +1,345 @@
+/**
+ * ArticleLinkExtractor.cpp
+ * Implementation of the ArticleLinkExtractor class
+ */
+
+#include "articlelinkextractor.h"
+#include <QDomElement>
+#include <Syndication/Item>
+
+namespace FeedCore
+{
+
+class ArticleLinkItem : public Syndication::Item
+{
+public:
+    ArticleLink m_link;
+    explicit ArticleLinkItem(const ArticleLink &link)
+        : m_link(link)
+    {
+    }
+
+    Syndication::SpecificItemPtr specificItem() const override
+    {
+        return Syndication::SpecificItemPtr(nullptr);
+    }
+
+    QString title() const override
+    {
+        return m_link.linkText;
+    }
+    QString link() const override
+    {
+        return m_link.url.toString();
+    }
+
+    QString description() const override
+    {
+        return QString();
+    }
+
+    QString content() const override
+    {
+        return QString();
+    }
+
+    time_t datePublished() const override
+    {
+        if (m_link.hasDate()) {
+            return m_link.date.toSecsSinceEpoch();
+        }
+        return 0;
+    }
+    time_t dateUpdated() const override
+    {
+        return datePublished();
+    }
+
+    QString id() const override
+    {
+        return m_link.url.toString();
+    }
+
+    QList<Syndication::PersonPtr> authors() const override
+    {
+        return QList<Syndication::PersonPtr>();
+    }
+
+    QString language() const override
+    {
+        // return system language by default
+        return QLocale::system().name();
+    }
+
+    QList<Syndication::EnclosurePtr> enclosures() const override
+    {
+        return QList<Syndication::EnclosurePtr>();
+    }
+
+    QList<Syndication::CategoryPtr> categories() const override
+    {
+        return QList<Syndication::CategoryPtr>();
+    }
+
+    int commentsCount() const override
+    {
+        return 0;
+    }
+
+    QString commentsLink() const override
+    {
+        return QString();
+    }
+
+    QString commentsFeed() const override
+    {
+        return QString();
+    }
+
+    QString commentPostUri() const override
+    {
+        return QString();
+    }
+
+    QMultiMap<QString, QDomElement> additionalProperties() const override
+    {
+        return QMultiMap<QString, QDomElement>();
+    }
+};
+
+class ArticleLinkFeed : public Syndication::Feed
+{
+public:
+    QString m_title;
+    QString m_url;
+    QList<ArticleLink> m_articleLinks;
+    explicit ArticleLinkFeed(const QString &title, const QString &url, const QList<ArticleLink> &articleLinks)
+        : m_title(title)
+        , m_url(url)
+        , m_articleLinks(articleLinks)
+    {
+    }
+
+    Syndication::SpecificDocumentPtr specificDocument() const override
+    {
+        return Syndication::SpecificDocumentPtr(nullptr);
+    }
+
+    QList<Syndication::ItemPtr> items() const override
+    {
+        QList<Syndication::ItemPtr> itemList;
+        for (const ArticleLink &link : m_articleLinks) {
+            itemList.append(Syndication::ItemPtr(new ArticleLinkItem(link)));
+        }
+        return itemList;
+    }
+    QList<Syndication::CategoryPtr> categories() const override
+    {
+        return QList<Syndication::CategoryPtr>();
+    }
+
+    QString title() const override
+    {
+        return m_title;
+    }
+    QString link() const override
+    {
+        return m_url;
+    }
+    QString description() const override
+    {
+        return QString();
+    }
+    Syndication::ImagePtr image() const override
+    {
+        return Syndication::ImagePtr();
+    }
+    Syndication::ImagePtr icon() const override
+    {
+        return Syndication::ImagePtr();
+    }
+    QList<Syndication::PersonPtr> authors() const override
+    {
+        return QList<Syndication::PersonPtr>();
+    }
+    QString language() const override
+    {
+        // return system language by default
+        return QLocale::system().name();
+    }
+    QString copyright() const override
+    {
+        return QString();
+    }
+    QMultiMap<QString, QDomElement> additionalProperties() const override
+    {
+        return QMultiMap<QString, QDomElement>();
+    }
+};
+
+enum { EmptyLinkScore = -1, DefaultLinkScore = 0, ExcludeLinkScore = 1, SubstanitalContentScore = 2, IncludeLinkScore = 3, DateLinkScore = 4 };
+
+ArticleLinkExtractor::ArticleLinkExtractor(const QString &input, const QUrl &baseUrl)
+    : GumboVisitor(input)
+    , m_inAnchor(false)
+    , m_inTitle(false)
+    , m_baseUrl(baseUrl)
+    , m_highestScore(0)
+    , m_datePattern(R"(/(\d{4})/(\d{2})/(\d{2})/)")
+{
+}
+
+ArticleLinkExtractor::ArticleLinkExtractor(const QByteArray &utf8data, const QUrl &baseUrl)
+    : GumboVisitor(utf8data)
+    , m_inAnchor(false)
+    , m_inTitle(false)
+    , m_baseUrl(baseUrl)
+    , m_datePattern(R"(/(\d{4})/(\d{2})/(\d{2})/)")
+{
+}
+
+void ArticleLinkExtractor::setBaseUrl(const QUrl &baseUrl)
+{
+    m_baseUrl = baseUrl;
+}
+
+ArticleLinkExtractor::~ArticleLinkExtractor()
+{
+}
+
+QList<ArticleLink> ArticleLinkExtractor::articleLinks() const
+{
+    return m_articleLinks;
+}
+
+Syndication::FeedPtr ArticleLinkExtractor::articleLinksFeed() const
+{
+    // Create a feed with the extracted article links
+    QString title = !m_pageTitle.isEmpty() ? m_pageTitle : "Extracted Article Links";
+    QString url = m_baseUrl.isValid() ? m_baseUrl.toString() : "http://example.com";
+    Syndication::FeedPtr feed(new ArticleLinkFeed(title, url, m_articleLinks));
+    return feed;
+}
+
+void ArticleLinkExtractor::visitElementOpen(GumboNode *node)
+{
+    if (node->v.element.tag == GUMBO_TAG_A) {
+        m_inAnchor = true;
+        m_currentLinkText.clear();
+
+        // Extract href attribute
+        GumboAttribute *href = gumbo_get_attribute(&node->v.element.attributes, "href");
+        if (href) {
+            m_currentHref = QString::fromUtf8(href->value);
+        } else {
+            m_currentHref.clear();
+        }
+    } else if (node->v.element.tag == GUMBO_TAG_TITLE) {
+        m_inTitle = true;
+        m_pageTitle.clear();
+    }
+}
+
+void ArticleLinkExtractor::visitText(GumboNode *node)
+{
+    if (m_inAnchor) {
+        // Append text content to current link text
+        m_currentLinkText += QString::fromUtf8(node->v.text.text);
+    } else if (m_inTitle) {
+        // Capture the page title
+        m_pageTitle += QString::fromUtf8(node->v.text.text);
+    }
+}
+
+void ArticleLinkExtractor::visitElementClose(GumboNode *node)
+{
+    if (node->v.element.tag == GUMBO_TAG_A && !m_currentHref.isEmpty()) {
+        auto score = articleLinkScore(m_currentHref, m_currentLinkText);
+        if (score > m_highestScore) {
+            m_highestScore = score;
+            m_articleLinks.clear();
+        }
+        if (score == m_highestScore) {
+            ArticleLink link;
+            QUrl url(m_currentHref);
+            if (m_baseUrl.isValid() && url.isRelative()) {
+                url = m_baseUrl.resolved(url);
+            }
+            link.url = url;
+            link.linkText = m_currentLinkText.trimmed();
+
+            if (score == DateLinkScore) {
+                QRegularExpressionMatch match = m_datePattern.match(m_currentHref);
+                if (match.hasMatch()) {
+                    int year = match.captured(1).toInt();
+                    int month = match.captured(2).toInt();
+                    int day = match.captured(3).toInt();
+
+                    link.date = QDateTime(QDate(year, month, day), QTime(0, 0));
+                }
+            }
+
+            m_articleLinks.append(link);
+        }
+
+        m_inAnchor = false;
+    } else if (node->v.element.tag == GUMBO_TAG_TITLE) {
+        m_inTitle = false;
+    }
+}
+
+int ArticleLinkExtractor::articleLinkScore(const QString &url, const QString &linkText)
+{
+    // Skip empty links or links without text
+    if (url.isEmpty() || linkText.trimmed().isEmpty()) {
+        qDebug() << url << "excluded due to empty link or text";
+        return EmptyLinkScore;
+    }
+
+    // Skip navigation links, social media links, etc.
+    static const QStringList excludePatterns = {"#",
+                                                "javascript:",
+                                                "mailto:",
+                                                "tel:",
+                                                "/tag/",
+                                                "/category/",
+                                                "/author/",
+                                                "/page/",
+                                                "facebook.com",
+                                                "twitter.com",
+                                                "instagram.com",
+                                                "youtube.com",
+                                                "/login",
+                                                "/register",
+                                                "/subscribe",
+                                                "/about",
+                                                "/contact"};
+
+    for (const auto &pattern : excludePatterns) {
+        if (url.contains(pattern, Qt::CaseInsensitive)) {
+            return ExcludeLinkScore;
+        }
+    }
+
+    if (m_datePattern.match(url).hasMatch()) {
+        return DateLinkScore;
+    }
+
+    static const QStringList articlePatterns = {"/article/", "/story/", "/blog/", "/post/", "/entry/", ".html", ".php"};
+
+    for (const auto &pattern : articlePatterns) {
+        if (url.contains(pattern, Qt::CaseInsensitive)) {
+            return IncludeLinkScore;
+        }
+    }
+
+    // Favor links with substantial text (likely a headline)
+    if (linkText.length() > 20 && linkText.length() < 200) {
+        return SubstanitalContentScore;
+    }
+
+    // Default score for anything else
+    return DefaultLinkScore;
+}
+
+} // namespace FeedCore

--- a/feedcore/articlelinkextractor.h
+++ b/feedcore/articlelinkextractor.h
@@ -21,7 +21,7 @@ namespace FeedCore
 struct ArticleLink {
     QUrl url;
     QString linkText;
-    QDateTime date; // Optional, will be valid only if date was extracted from URL
+    QDateTime date; // will be valid only if date was extracted from URL
 
     bool hasDate() const
     {
@@ -58,25 +58,15 @@ private:
     QString m_currentLinkText;
     QString m_currentHref;
     QList<ArticleLink> m_articleLinks;
+    QHash<QUrl, qsizetype> m_urlIndices;
     QUrl m_baseUrl;
     int m_highestScore;
 
     // Regular expression to extract date from URL pattern /YYYY/MM/DD/
     const QRegularExpression m_datePattern;
 
-    /**
-     * Called when an opening HTML tag is encountered
-     */
     void visitElementOpen(GumboNode *node) override;
-
-    /**
-     * Called when text content is encountered
-     */
     void visitText(GumboNode *node) override;
-
-    /**
-     * Called when a closing HTML tag is encountered
-     */
     void visitElementClose(GumboNode *node) override;
 
     /**

--- a/feedcore/articlelinkextractor.h
+++ b/feedcore/articlelinkextractor.h
@@ -1,0 +1,89 @@
+/**
+ * ArticleLinkExtractor.h
+ * A GumboVisitor subclass that extracts article links from web pages
+ */
+
+#pragma once
+#include "gumbovisitor.h"
+#include <QDateTime>
+#include <QList>
+#include <QPair>
+#include <QRegularExpression>
+#include <QUrl>
+#include <Syndication/Feed>
+
+namespace FeedCore
+{
+
+/**
+ * Structure to hold article link information
+ */
+struct ArticleLink {
+    QUrl url;
+    QString linkText;
+    QDateTime date; // Optional, will be valid only if date was extracted from URL
+
+    bool hasDate() const
+    {
+        return date.isValid();
+    }
+};
+
+/**
+ * Extracts article links from HTML using GumboVisitor
+ */
+class ArticleLinkExtractor : public GumboVisitor
+{
+public:
+    explicit ArticleLinkExtractor(const QString &input, const QUrl &baseUrl = QUrl());
+    explicit ArticleLinkExtractor(const QByteArray &utf8data, const QUrl &baseUrl = QUrl());
+    virtual ~ArticleLinkExtractor();
+
+    void setBaseUrl(const QUrl &baseUrl);
+
+    /**
+     * Returns the list of article links extracted from the HTML
+     */
+    QList<ArticleLink> articleLinks() const;
+
+    /**
+     * returns a Syndication::Feed containing the article links
+     */
+    Syndication::FeedPtr articleLinksFeed() const;
+
+private:
+    bool m_inAnchor;
+    bool m_inTitle;
+    QString m_pageTitle;
+    QString m_currentLinkText;
+    QString m_currentHref;
+    QList<ArticleLink> m_articleLinks;
+    QUrl m_baseUrl;
+    int m_highestScore;
+
+    // Regular expression to extract date from URL pattern /YYYY/MM/DD/
+    const QRegularExpression m_datePattern;
+
+    /**
+     * Called when an opening HTML tag is encountered
+     */
+    void visitElementOpen(GumboNode *node) override;
+
+    /**
+     * Called when text content is encountered
+     */
+    void visitText(GumboNode *node) override;
+
+    /**
+     * Called when a closing HTML tag is encountered
+     */
+    void visitElementClose(GumboNode *node) override;
+
+    /**
+     * Determines if a link is likely to be an article link based on
+     * URL and link text heuristics
+     */
+    int articleLinkScore(const QString &url, const QString &linkText);
+};
+
+} // namespace FeedCore

--- a/feedcore/feed.cpp
+++ b/feedcore/feed.cpp
@@ -297,15 +297,22 @@ void Feed::Updater::finish()
 {
     d->feed->setLastUpdate(d->updateStartTime);
     d->feed->setStatus(LoadStatus::Idle);
+    cleanup();
 }
 
 void Feed::Updater::setError(const QString &errorMsg)
 {
     d->errorMsg = errorMsg;
     d->feed->setStatus(LoadStatus::Error);
+    cleanup();
 }
 
 void Feed::Updater::aborted()
 {
     d->feed->setStatus(LoadStatus::Idle);
+    cleanup();
+}
+
+void Feed::Updater::cleanup()
+{
 }

--- a/feedcore/feed.h
+++ b/feedcore/feed.h
@@ -124,7 +124,8 @@ public:
     Q_ENUM(UpdateMode)
 
     enum FeedFlags {
-        UseReadableContentFlag = 1 /** < always use web content from readability */
+        UseReadableContentFlag = 1, /** < always use web content from readability */
+        IsWebPageFlag = 1U << 1U /** < this feed is a web page, not an RSS/Atom feed */
     };
     Q_FLAGS(FeedFlags)
 

--- a/feedcore/feed.h
+++ b/feedcore/feed.h
@@ -299,6 +299,13 @@ private:
      * Implemented by derived classes to perform the update.
      */
     virtual void run() = 0;
+
+    /**
+     * Implemented by derived classes to clean up after an update.
+     *
+     * This is called at the end of an update whether is succeeded, failed, or was aborted.
+     */
+    virtual void cleanup();
 };
 
 typedef Feed::LoadStatus LoadStatus;

--- a/feedcore/networkaccessmanager.cpp
+++ b/feedcore/networkaccessmanager.cpp
@@ -142,10 +142,20 @@ void NetworkAccessManager::DeferredNetworkReply::forwardHeaders()
     forwardAttribute(QNetworkRequest::SourceIsFromCacheAttribute);
 }
 
+static std::unique_ptr<NetworkAccessManager> networkAccessManagerInstance;
+
 NetworkAccessManager *NetworkAccessManager::instance()
 {
-    static auto *singleton = new NetworkAccessManager(new SharedCache);
-    return singleton;
+    if (auto instance = networkAccessManagerInstance.get()) {
+        return instance;
+    }
+    networkAccessManagerInstance = std::make_unique<NetworkAccessManager>(new SharedCache);
+    return networkAccessManagerInstance.get();
+}
+
+void NetworkAccessManager::setInstance(NetworkAccessManager *instance)
+{
+    networkAccessManagerInstance.reset(instance);
 }
 
 FeedCore::NetworkAccessManager::NetworkAccessManager(QObject *parent)

--- a/feedcore/networkaccessmanager.h
+++ b/feedcore/networkaccessmanager.h
@@ -27,6 +27,7 @@ class NetworkAccessManager : public QNetworkAccessManager
 {
 public:
     static NetworkAccessManager *instance();
+    static void setInstance(NetworkAccessManager *instance);
 
     explicit NetworkAccessManager(QObject *parent = nullptr);
     explicit NetworkAccessManager(QAbstractNetworkCache *cache, QObject *parent = nullptr);

--- a/feedcore/provisionalfeed.cpp
+++ b/feedcore/provisionalfeed.cpp
@@ -28,6 +28,7 @@ void ProvisionalFeed::onUrlChanged()
     syncUrlString();
     updater()->abort();
     m_feed = nullptr;
+    setFlags(flags() & ~Feed::IsWebPageFlag);
     emit reset();
 }
 

--- a/feedcore/provisionalfeed.cpp
+++ b/feedcore/provisionalfeed.cpp
@@ -60,7 +60,9 @@ QFuture<void> ProvisionalFeed::updateFromSource(const Syndication::FeedPtr &feed
         setName(feed->title());
     }
     setLink(feed->link());
-    setIcon(feed->icon()->url());
+    if (auto icon = feed->icon()) {
+        setIcon(icon->url());
+    }
     setUnreadCount(feed->items().size());
     m_feed = feed;
     emit reset();

--- a/feedcore/updatablefeed.cpp
+++ b/feedcore/updatablefeed.cpp
@@ -89,7 +89,7 @@ private:
     UpdatableFeed *m_updatableFeed{nullptr};
     std::unique_ptr<Update> m_currentUpdate;
 
-    void onSucceeded(const Syndication::FeedPtr &feed, const QUrl &changeUrl);
+    void onSucceeded(const Syndication::FeedPtr &feed);
     void onFailed(const QString &errorString);
 };
 
@@ -178,14 +178,13 @@ void UpdatableFeed::UpdaterImpl::abort()
 
 void UpdatableFeed::UpdaterImpl::cleanup()
 {
-    m_currentUpdate.release()->deleteLater();
+    if (auto *update = m_currentUpdate.release()) {
+        update->deleteLater();
+    }
 }
 
-void UpdatableFeed::UpdaterImpl::onSucceeded(const Syndication::FeedPtr &feed, const QUrl &changeUrl)
+void UpdatableFeed::UpdaterImpl::onSucceeded(const Syndication::FeedPtr &feed)
 {
-    if (changeUrl.isValid()) {
-        m_updatableFeed->setUrl(changeUrl);
-    }
     auto whenDone = m_updatableFeed->updateFromSource(feed);
     Future::safeThen(whenDone, this, [this](auto) {
         finish();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,3 +32,7 @@ target_link_libraries(testArticleSummary PRIVATE Qt6::Test feedcore)
 add_executable(testAutomationEngine tst_automationengine.cpp)
 add_test(NAME testAutomationEngine COMMAND testAutomationEngine)
 target_link_libraries(testAutomationEngine PRIVATE Qt6::Test feedcore)
+
+add_executable(testWebPageFallback tst_webpage_fallback.cpp)
+add_test(NAME testWebPageFallback COMMAND testWebPageFallback)
+target_link_libraries(testWebPageFallback PRIVATE Qt6::Test feedcore)

--- a/test/tst_webpage_fallback.cpp
+++ b/test/tst_webpage_fallback.cpp
@@ -1,0 +1,308 @@
+/**
+ * SPDX-FileCopyrightText: 2022 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "networkaccessmanager.h"
+#include "provisionalfeed.h"
+#include "updatablefeed.h"
+#include <QCoreApplication>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QSignalSpy>
+#include <QtTest>
+#include <Syndication/Feed>
+#include <Syndication/ParserCollection>
+
+using namespace FeedCore;
+
+// Mock network reply class
+class MockNetworkReply : public QNetworkReply
+{
+public:
+    explicit MockNetworkReply(QObject *parent = nullptr)
+        : QNetworkReply(parent)
+    {
+    }
+
+    void setData(const QByteArray &data)
+    {
+        m_data = data;
+        m_offset = 0;
+    }
+
+    void setUrl(const QUrl &url)
+    {
+        QNetworkReply::setUrl(url);
+    }
+
+    void setError(QNetworkReply::NetworkError error, const QString &errorString)
+    {
+        QNetworkReply::setError(error, errorString);
+    }
+
+    void finish()
+    {
+        emit finished();
+    }
+
+    bool open(OpenMode mode) override
+    {
+        if (mode != ReadOnly) {
+            return false;
+        }
+
+        setOpenMode(ReadOnly);
+        return QNetworkReply::open(mode);
+    }
+
+    void abort() override
+    {
+        setError(OperationCanceledError, "Aborted");
+        emit finished();
+    }
+    qint64 bytesAvailable() const override
+    {
+        return m_data.size() - m_offset;
+    }
+    bool isSequential() const override
+    {
+        return true;
+    }
+
+protected:
+    qint64 readData(char *data, qint64 maxSize) override
+    {
+        if (m_offset >= m_data.size())
+            return -1;
+
+        qint64 bytesToRead = qMin(maxSize, static_cast<qint64>(m_data.size() - m_offset));
+        memcpy(data, m_data.constData() + m_offset, bytesToRead);
+        m_offset += bytesToRead;
+        return bytesToRead;
+    }
+
+private:
+    QByteArray m_data;
+    qint64 m_offset = 0;
+};
+
+// Mock network access manager for testing
+class MockNetworkAccessManager : public FeedCore::NetworkAccessManager
+{
+public:
+    explicit MockNetworkAccessManager(QObject *parent = nullptr)
+        : FeedCore::NetworkAccessManager(parent)
+    {
+    }
+
+    QNetworkReply *createRequest(Operation op, const QNetworkRequest &request, QIODevice *outgoingData = nullptr) override
+    {
+        Q_UNUSED(op);
+        Q_UNUSED(outgoingData);
+
+        if (!m_responses.contains(request.url())) {
+            auto *reply = new MockNetworkReply(this);
+            reply->setUrl(request.url());
+            reply->setError(QNetworkReply::ContentNotFoundError, "URL not found in mock responses");
+            QTimer::singleShot(0, reply, &MockNetworkReply::finish);
+            return reply;
+        }
+
+        auto *reply = new MockNetworkReply(this);
+        reply->setUrl(request.url());
+        reply->setData(m_responses[request.url()]);
+        reply->open(QIODevice::ReadOnly);
+        QTimer::singleShot(0, reply, &MockNetworkReply::finish);
+        return reply;
+    }
+
+    void addResponse(const QUrl &url, const QByteArray &data)
+    {
+        m_responses[url] = data;
+    }
+
+private:
+    QMap<QUrl, QByteArray> m_responses;
+};
+
+class TestWebPageFallback : public QObject
+{
+    Q_OBJECT
+
+private:
+    QPointer<MockNetworkAccessManager> m_networkManager;
+    QScopedPointer<UpdatableFeed> m_feed;
+
+    // Sample data
+    const QByteArray m_atomFeedData = QByteArray(
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        "<feed xmlns=\"http://www.w3.org/2005/Atom\">"
+        "  <title>Test Feed</title>"
+        "  <link href=\"https://example.org/\"/>"
+        "  <updated>2023-01-01T12:00:00Z</updated>"
+        "  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>"
+        "  <entry>"
+        "    <title>Sample Article 1</title>"
+        "    <link href=\"https://example.org/article1\"/>"
+        "    <id>article1-id</id>"
+        "    <updated>2023-01-01T12:00:00Z</updated>"
+        "    <summary>Sample content 1</summary>"
+        "  </entry>"
+        "</feed>");
+
+    const QByteArray m_webPageWithFeedLinksData = QByteArray(
+        "<html><head>"
+        "<link rel=\"alternate\" type=\"application/rss+xml\" href=\"https://example.org/feed.xml\">"
+        "</head><body>"
+        "<h1>Example Website</h1>"
+        "<p>This is a sample web page with a feed link.</p>"
+        "</body></html>");
+
+    const QByteArray m_webPageWithArticleLinksData = QByteArray(
+        "<html><head><title>Example News Site</title></head><body>"
+        "<h1>Latest Articles</h1>"
+        "<ul>"
+        "  <li><a href=\"https://example.org/article1\">Article 1 Title</a></li>"
+        "  <li><a href=\"https://example.org/article2\">Article 2 Title</a></li>"
+        "  <li><a href=\"https://example.org/about\">About Us</a></li>"
+        "</ul>"
+        "</body></html>");
+
+    void initTestCase()
+    {
+        qRegisterMetaType<FeedCore::Feed::LoadStatus>();
+        qRegisterMetaType<FeedCore::Feed *>();
+    }
+
+    void init()
+    {
+        m_networkManager = new MockNetworkAccessManager();
+        FeedCore::NetworkAccessManager::setInstance(m_networkManager.get());
+        m_feed.reset(new ProvisionalFeed());
+    }
+
+    void cleanup()
+    {
+        m_feed.reset();
+    }
+
+    // Test Case A: Feed URLs that point to actual RSS/Atom feeds should load feed content
+    void testDirectFeed()
+    {
+        // Set up test data
+        QUrl feedUrl("https://example.org/feed.xml");
+        m_networkManager->addResponse(feedUrl, m_atomFeedData);
+
+        // Set up signal spies
+        QSignalSpy statusSpy(m_feed.get(), &Feed::statusChanged);
+
+        // Set the feed URL and start the update
+        m_feed->setUrl(feedUrl);
+        m_feed->updater()->start();
+
+        // Wait for the update to complete
+        QTest::qWait(500);
+
+        // Verify the feed loaded correctly
+        QCOMPARE(m_feed->status(), Feed::Idle);
+        QCOMPARE(m_feed->name(), QString("Test Feed"));
+        QCOMPARE(m_feed->flags() & Feed::IsWebPageFlag, 0); // Should not have web page flag
+
+        // Verify status changes: Idle -> Updating -> Idle
+        QCOMPARE(statusSpy.count(), 2);
+    }
+
+    // Test Case B: Feed URLs pointing to web pages should try to discover feeds first
+    void testWebPageWithFeedDiscovery()
+    {
+        // Set up test data for a web page with feed discovery link
+        QUrl webpageUrl("https://example.org/blog");
+        QUrl discoveredFeedUrl("https://example.org/feed.xml");
+
+        m_networkManager->addResponse(webpageUrl, m_webPageWithFeedLinksData);
+        m_networkManager->addResponse(discoveredFeedUrl, m_atomFeedData);
+        m_feed->setUrl(webpageUrl);
+
+        // Set up signal spies
+        QSignalSpy statusSpy(m_feed.get(), &Feed::statusChanged);
+        QSignalSpy urlChangedSpy(m_feed.get(), &Feed::urlChanged);
+
+        // Set the feed URL and start the update
+        m_feed->updater()->start();
+
+        // Wait for the update to complete
+        QTest::qWait(500);
+
+        // Verify the feed loaded correctly and URL was changed to the discovered feed
+        QCOMPARE(m_feed->status(), Feed::Idle);
+        QCOMPARE(m_feed->name(), QString("Test Feed"));
+        QCOMPARE(m_feed->url(), discoveredFeedUrl);
+        QCOMPARE(m_feed->flags() & Feed::IsWebPageFlag, 0); // Should not have web page flag
+
+        // Verify URL changed (from webpage to feed URL)
+        QCOMPARE(urlChangedSpy.count(), 1);
+    }
+
+    // Test Case C: Web pages with no discoverable feeds or failed feed loads should fall back to web page parsing
+    void testWebPageFallback()
+    {
+        // Set up test data for a web page with no feed links
+        QUrl webpageUrl("https://example.org/news");
+
+        m_networkManager->addResponse(webpageUrl, m_webPageWithArticleLinksData);
+
+        // Set up signal spies
+        QSignalSpy statusSpy(m_feed.get(), &Feed::statusChanged);
+        QSignalSpy flagsChangedSpy(m_feed.get(), &Feed::flagsChanged);
+
+        // Set the feed URL and start the update
+        m_feed->setUrl(webpageUrl);
+        m_feed->updater()->start();
+
+        // Wait for the update to complete
+        QTest::qWait(500);
+
+        // Verify the feed was processed as a web page
+        QCOMPARE(m_feed->status(), Feed::Idle);
+        QCOMPARE(m_feed->flags() & Feed::IsWebPageFlag, Feed::IsWebPageFlag); // Should have web page flag
+
+        // Verify flags changed (indicating web page mode was set)
+        QCOMPARE(flagsChangedSpy.count(), 1);
+    }
+
+    // Test Case C-2: Web page with discoverable feed, but feed fails to load
+    void testWebPageFallbackWhenFeedLoadFails()
+    {
+        // Set up test data for a web page with feed discovery link
+        QUrl webpageUrl("https://example.org/news");
+        QUrl discoveredFeedUrl("https://example.org/feed.xml");
+
+        // Add the web page response
+        m_networkManager->addResponse(webpageUrl, m_webPageWithFeedLinksData);
+
+        // But make the discovered feed URL fail (not adding a response for it)
+        // The MockNetworkAccessManager will return a ContentNotFoundError for this URL
+
+        // Set up signal spies
+        QSignalSpy statusSpy(m_feed.get(), &Feed::statusChanged);
+        QSignalSpy flagsChangedSpy(m_feed.get(), &Feed::flagsChanged);
+
+        // Set the feed URL and start the update
+        m_feed->setUrl(webpageUrl);
+        m_feed->updater()->start();
+
+        // Wait for the update to complete
+        QTest::qWait(500);
+
+        // Verify the feed was processed as a web page after feed loading failed
+        QCOMPARE(m_feed->status(), Feed::Idle);
+        QCOMPARE(m_feed->flags() & Feed::IsWebPageFlag, Feed::IsWebPageFlag); // Should have web page flag
+
+        // Verify flags changed (indicating web page mode was set)
+        QCOMPARE(flagsChangedSpy.count(), 1);
+    }
+};
+
+QTEST_MAIN(TestWebPageFallback)
+#include "tst_webpage_fallback.moc"


### PR DESCRIPTION
Adds a new flag for a feed that is actually a web page. These are processed using our existing gumbo-based HTML processing infrastructure to identify likely article links based on common URL patterns. The result is a basic links-only feed.

The web page flag is not set by the user, rather it gets set automatically when feed discovery is attempted but fails to yield a suitable feed.