### PR TITLE
Use dense_rank instead of rank when ranking highlights

### DIFF
--- a/sqlite/feeddatabase.cpp
+++ b/sqlite/feeddatabase.cpp
@@ -174,7 +174,7 @@ ItemQuery FeedDatabase::selectItemsByRecommended(int limit)
     q.prepare(
                 "SELECT "+
                     ItemQuery::fieldList() + ", "
-                    "RANK() over (PARTITION BY feed ORDER BY date DESC) AS feedRank "
+                    "DENSE_RANK() over (PARTITION BY feed ORDER BY date DESC) AS feedRank "
                 "FROM Item "
                 "ORDER BY isRead ASC, feedRank ASC, date ASC "
                 "LIMIT :limit;"


### PR DESCRIPTION
This avoids the highlights having a "clump" of articles from the same source when a source published many articles with the same timestamp