### PR TITLE
Move "Highlights" into the feed list as a special feed

### DIFF
--- a/feedcore/CMakeLists.txt
+++ b/feedcore/CMakeLists.txt
@@ -23,6 +23,7 @@ set(feedcore_HEADERS
     feeddiscovery.h
     searchresultfeed.h
     articlelinkextractor.h
+    highlightsfeed.h
     automation/automationengine.h
     automation/automationrule.h
     readability/readability.h
@@ -49,6 +50,7 @@ set(feedcore_SRCS
     feeddiscovery.cpp
     searchresultfeed.cpp
     articlelinkextractor.cpp
+    highlightsfeed.cpp
     automation/abstractautomationrule.h
     automation/automationengine.cpp
     automation/automationrule.cpp

--- a/feedcore/highlightsfeed.cpp
+++ b/feedcore/highlightsfeed.cpp
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: 2021 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "highlightsfeed.h"
+#include "context.h"
+
+namespace FeedCore
+{
+
+class HighlightsFeed::HighlightsUpdater : public Updater
+{
+public:
+    explicit HighlightsUpdater(HighlightsFeed *parent)
+        : Updater(parent, parent)
+    {
+    }
+
+    void run() override
+    {
+        finish();
+    }
+};
+
+HighlightsFeed::HighlightsFeed(Context *context, const QString &name, QObject *parent)
+    : Feed(parent)
+    , m_context{context}
+    , m_updater{new HighlightsUpdater(this)}
+{
+    setName(name);
+}
+
+QFuture<ArticleRef> HighlightsFeed::getArticles(bool /*unused*/)
+{
+    return m_context->getHighlights();
+}
+
+Feed::Updater *HighlightsFeed::updater()
+{
+    return m_updater;
+}
+
+}

--- a/feedcore/highlightsfeed.h
+++ b/feedcore/highlightsfeed.h
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: 2021 Connor Carney <hello@connorcarney.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+#include "feed.h"
+
+namespace FeedCore
+{
+class Context;
+
+/**
+ * A Feed implementation which displays highlights from
+ * all feeds in a context.
+ */
+class HighlightsFeed : public Feed
+{
+public:
+    HighlightsFeed(Context *context, const QString &name, QObject *parent = nullptr);
+    QFuture<ArticleRef> getArticles(bool unreadFilter) final;
+    Updater *updater() final;
+
+private:
+    Context *m_context{nullptr};
+    Updater *m_updater{nullptr};
+    class HighlightsUpdater;
+};
+}

--- a/src/feedlistmodel.cpp
+++ b/src/feedlistmodel.cpp
@@ -5,6 +5,7 @@
 
 #include "feedlistmodel.h"
 #include "context.h"
+#include "highlightsfeed.h"
 #include "iconprovider.h"
 #include "starreditemsfeed.h"
 #include <QList>
@@ -17,7 +18,7 @@ using namespace FeedCore;
 
 namespace
 {
-enum SpecialFeedIndex { ALL_ITEMS_IDX = 0, STARRED_ITEMS_IDX, SPECIAL_FEED_COUNT };
+enum SpecialFeedIndex { ALL_ITEMS_IDX = 0, HIGHLIGHTS_IDX, STARRED_ITEMS_IDX, SPECIAL_FEED_COUNT };
 
 class SortHelper : public FeedSortNotifier
 {
@@ -98,6 +99,7 @@ public:
     Context *context = nullptr;
     QSharedPointer<Feed> allItems = nullptr;
     StarredItemsFeed *starredItems = nullptr;
+    HighlightsFeed *highlightsFeed = nullptr;
     QList<FeedCore::Feed *> feeds;
     Sort sortMode = Name;
     std::unique_ptr<SortHelper> sortHelper = std::make_unique<NameSortHelper>();
@@ -160,6 +162,7 @@ void FeedListModel::setContext(FeedCore::Context *context)
         d->allItems = d->context->allItemsFeed();
         d->allItems->setName(tr("All Items", "special feed name"));
         d->starredItems = new StarredItemsFeed(d->context, tr("Starred Items", "special feed name"), this);
+        d->highlightsFeed = new HighlightsFeed(d->context, tr("Highlights", "special feed name"), this);
     }
     emit contextChanged();
 }
@@ -187,6 +190,9 @@ QVariant FeedListModel::data(const QModelIndex &index, int role) const
         break;
     case STARRED_ITEMS_IDX:
         entry = d->starredItems;
+        break;
+    case HIGHLIGHTS_IDX:
+        entry = d->highlightsFeed;
         break;
     default:
         entry = d->feeds[indexRow - SPECIAL_FEED_COUNT];
@@ -261,7 +267,21 @@ QString FeedListModel::pageUrlFor(FeedCore::Feed *feed)
     if (feed == d->starredItems) {
         return QStringLiteral("qrc:/qml/ArticleList/StarredItemsPage.qml");
     }
+    if (feed == d->highlightsFeed) {
+        return QStringLiteral("qrc:/qml/ArticleList/OverviewPage.qml");
+    }
     return QStringLiteral("qrc:/qml/ArticleList/FeedPage.qml");
+}
+
+QString FeedListModel::themeIconFor(FeedCore::Feed *feed)
+{
+    if (feed == d->starredItems) {
+        return QStringLiteral("starred-symbolic");
+    }
+    if (feed == d->highlightsFeed) {
+        return QStringLiteral("go-home-symbolic");
+    }
+    return QStringLiteral("feed-subscribe");
 }
 
 void FeedListModel::loadFeeds()

--- a/src/feedlistmodel.h
+++ b/src/feedlistmodel.h
@@ -38,6 +38,7 @@ public:
     void setSortMode(Sort sortMode);
     Q_INVOKABLE int indexOf(FeedCore::Feed *feed);
     Q_INVOKABLE QString pageUrlFor(FeedCore::Feed *feed);
+    Q_INVOKABLE QString themeIconFor(FeedCore::Feed *feed);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const final;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const final;

--- a/src/qml/FeedIcon.qml
+++ b/src/qml/FeedIcon.qml
@@ -7,7 +7,8 @@ Kirigami.Icon {
     required property Feed feed
     property alias size: root.implicitWidth
     property string iconName: feed.icon.toString()
-    source: iconName.length ? "image://feedicons/"+iconName : "feed-subscribe"
+    property string themeIcon: "feed-subscribe"
+    source: iconName.length ? "image://feedicons/"+iconName : themeIcon
     placeholder: "feed-subscribe"
     fallback: "feed-subscribe"
     implicitWidth: Kirigami.Units.iconSizes.smallMedium

--- a/src/qml/FeedList.qml
+++ b/src/qml/FeedList.qml
@@ -45,6 +45,7 @@ ListView {
 
             FeedIcon {
                 feed: listItem.feed
+                themeIcon: feedListModel.themeIconFor(feed)
             }
 
             Delegates.TitleSubtitle {

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -108,14 +108,6 @@ Kirigami.ApplicationWindow {
         }
 
         actions: [
-            Kirigami.Action {
-                id: highlightsAction
-                text: qsTr("Highlights")
-                icon.name: "go-home-symbolic"
-                onTriggered: {
-                    priv.pushUtilityPage("qrc:/qml/ArticleList/OverviewPage.qml", {pageRow: pageStack})
-                }
-            },
 
             Kirigami.Action {
                 text: qsTr("Add Content")
@@ -249,7 +241,7 @@ Kirigami.ApplicationWindow {
         switch (globalSettings.startPage) {
         default:
         case 0:
-            highlightsAction.trigger();
+            feedList.currentIndex = 1; // Highlights feed
             break;
 
         case 1:


### PR DESCRIPTION
Previously we had it as an action at the bottom of the global drawer, but it's a better conceptual fit with e.g. the starred items feed. This introduced a new special Feed type to represent the highlights and adds it to the main feed list.